### PR TITLE
Adding EngineState in the ChaosEngine spec

### DIFF
--- a/utils/chaosengine.j2
+++ b/utils/chaosengine.j2
@@ -10,6 +10,7 @@ spec:
       image: "litmuschaos/chaos-runner:latest"
       type: "go"   
   jobCleanUpPolicy: delete
+  engineState: 'active'
   monitoring: false
   appinfo: 
     appns: {{ a_ns }}


### PR DESCRIPTION
Signed-off-by: Udit Gaurav <uditgaurav@gmail.com>
- Adding EngineState in the ChaosEngine spec