### PR TITLE
(Enhancement): Changing the chaosengine and chaosrunner A/C to the latest changes

### DIFF
--- a/tests/openebs-pool-container-failure_test.go
+++ b/tests/openebs-pool-container-failure_test.go
@@ -185,32 +185,18 @@ var _ = Describe("BDD of openebs pool container failure experiment", func() {
 			Expect(err).To(BeNil(), "Fail to get the runner pod")
 			Expect(string(runner.Status.Phase)).To(Equal("Running"))
 
-			//Fetch job pod name
-			By("Fetch Job pod name")
+			//Waiting for experiment job to get completed
+			//Also print the logs of the job
+			By("Waiting for job completion")
 			jobPodLogs, err := utils.JobLogs(experimentName, engineName, client)
 			Expect(jobPodLogs).To(Equal(0), "Fail to print the logs of the experiment")
 			Expect(err).To(BeNil(), "Fail to get the experiment job pod")
 
-			//Running it for infinite time (say 30000s)
-			//The Gitlab job will quit if it takes more time than default time (10 min)
-			By("Wait for engine to come in Succeeded sate")
-			runnerAfter, err := client.CoreV1().Pods(chaosTypes.ChaosNamespace).Get(engineName+"-runner", metav1.GetOptions{})
-			for i := 0; i < 3000; i++ {
-				if string(runnerAfter.Status.Phase) != "Succeeded" {
-					time.Sleep(10 * time.Second)
-					runnerAfter, _ = client.CoreV1().Pods(chaosTypes.ChaosNamespace).Get(engineName+"-runner", metav1.GetOptions{})
-					fmt.Printf("Currently, the runner pod is in %v State, Please Wait ...\n", runnerAfter.Status.Phase)
-				} else {
-					break
-				}
-			}
-			Expect(err).To(BeNil())
-			Expect(string(runnerAfter.Status.Phase)).To(Equal("Succeeded"))
-
 			//Checking the chaosresult
 			By("Checking the chaosresult")
-			app, _ := clientSet.ChaosResults(chaosTypes.ChaosNamespace).Get("engine-openebs-pool-container-failure", metav1.GetOptions{})
-			Expect(string(app.Spec.ExperimentStatus.Verdict)).To(Equal("Pass"), "Verdict is not pass chaosresult")
+			app, err := clientSet.ChaosResults(chaosTypes.ChaosNamespace).Get(engineName+"-"+experimentName, metav1.GetOptions{})
+			Expect(string(app.Status.ExperimentStatus.Verdict)).To(Equal("Pass"), "Verdict is not pass chaosresult")
+			Expect(err).To(BeNil(), "Fail to get chaosresult")
 
 		})
 	})

--- a/tests/openebs-pool-pod-failure_test.go
+++ b/tests/openebs-pool-pod-failure_test.go
@@ -109,7 +109,7 @@ var _ = Describe("BDD test for openebs pool pod failure experiment", func() {
 			fmt.Println("PodIP of csp pod has been recorded")
 			fmt.Println("StartTime of csp pod has been recorded")
 
-			//Installing RBAC for the experiment  
+			//Installing RBAC for the experiment
 			//Fetching rbac file
 			rbacPath := "https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/openebs/openebs-pool-pod-failure/rbac.yaml"
 			installrbac, err := utils.InstallRbac(rbacPath, experimentName, client)
@@ -181,32 +181,18 @@ var _ = Describe("BDD test for openebs pool pod failure experiment", func() {
 			Expect(err).To(BeNil(), "Fail to get the runner pod")
 			Expect(string(runner.Status.Phase)).To(Equal("Running"))
 
-			//Fetch job pod name
-			By("Fetch Job pod name")
+			//Waiting for experiment job to get completed
+			//Also print the logs of the job
+			By("Waiting for job completion")
 			jobPodLogs, err := utils.JobLogs(experimentName, engineName, client)
 			Expect(jobPodLogs).To(Equal(0), "Fail to wait for job completion")
 			Expect(err).To(BeNil(), "Fail to print the logs of the experiment")
 
-			//Running it for infinite time (say 3000 * 10)
-			//The Gitlab job will quit if it takes more time than default time (10 min)
-			By("Wait for engine to come in Succeeded sate")
-			runnerAfter, err := client.CoreV1().Pods(chaosTypes.ChaosNamespace).Get(engineName+"-runner", metav1.GetOptions{})
-			for i := 0; i < 3000; i++ {
-				if string(runnerAfter.Status.Phase) != "Succeeded" {
-					time.Sleep(10 * time.Second)
-					runnerAfter, _ = client.CoreV1().Pods(chaosTypes.ChaosNamespace).Get(engineName+"-runner", metav1.GetOptions{})
-					fmt.Printf("Currently, the runner pod is in %v State, Please Wait ...\n", runnerAfter.Status.Phase)
-				} else {
-					break
-				}
-			}
-			Expect(err).To(BeNil())
-			Expect(string(runnerAfter.Status.Phase)).To(Equal("Succeeded"))
-
 			//Checking the chaosresult
 			By("Checking the chaosresult")
-			app, _ := clientSet.ChaosResults(chaosTypes.ChaosNamespace).Get("engine1-openebs-pool-pod-failure", metav1.GetOptions{})
-			Expect(string(app.Spec.ExperimentStatus.Verdict)).To(Equal("Pass"), "Verdict is not pass chaosresult")
+			app, err := clientSet.ChaosResults(chaosTypes.ChaosNamespace).Get(engineName+"-"+experimentName, metav1.GetOptions{})
+			Expect(string(app.Status.ExperimentStatus.Verdict)).To(Equal("Pass"), "Verdict is not pass chaosresult")
+			Expect(err).To(BeNil(), "Fail to get chaosresult")
 		})
 	})
 

--- a/tests/openebs-target-network-delay_test.go
+++ b/tests/openebs-target-network-delay_test.go
@@ -159,31 +159,18 @@ var _ = Describe("BDD of openebs target network delay", func() {
 			Expect(err).To(BeNil(), "Fail to get the runner pod")
 			Expect(string(runner.Status.Phase)).To(Equal("Running"))
 
-			//Fetch job pod name
-			By("Fetch Job pod name")
+			//Waiting for experiment job to get completed
+			//Also print the logs of the job
+			By("Waiting for job completion")
 			jobPodLogs, err := utils.JobLogs(experimentName, engineName, client)
 			Expect(jobPodLogs).To(Equal(0), "Fail to print the logs of the experiment")
 			Expect(err).To(BeNil(), "Fail to print the logs of the experiment")
 
-			//Running it for infinite time (say 3000 * 10)
-			//The Gitlab job will quit if it takes more time than default time (10 min)
-			By("Wait for engine to come in Succeeded sate")
-			runnerAfter, err := client.CoreV1().Pods(chaosTypes.ChaosNamespace).Get(engineName+"-runner", metav1.GetOptions{})
-			for i := 0; i < 3000; i++ {
-				if string(runnerAfter.Status.Phase) != "Succeeded" {
-					time.Sleep(10 * time.Second)
-					runnerAfter, _ = client.CoreV1().Pods(chaosTypes.ChaosNamespace).Get(engineName+"-runner", metav1.GetOptions{})
-					fmt.Printf("Currently, the runner pod is in %v State, Please Wait ...\n", runnerAfter.Status.Phase)
-				} else {
-					break
-				}
-			}
-			Expect(err).To(BeNil())
-			Expect(string(runnerAfter.Status.Phase)).To(Equal("Succeeded"))
 			//Checking the chaosresult
 			By("Checking the chaosresult")
-			app, _ := clientSet.ChaosResults(chaosTypes.ChaosNamespace).Get("engine4-openebs-target-network-delay", metav1.GetOptions{})
-			Expect(string(app.Spec.ExperimentStatus.Verdict)).To(Equal("Pass"), "Verdict is not pass chaosresult")
+			app, err := clientSet.ChaosResults(chaosTypes.ChaosNamespace).Get(engineName+"-"+experimentName, metav1.GetOptions{})
+			Expect(string(app.Status.ExperimentStatus.Verdict)).To(Equal("Pass"), "Verdict is not pass chaosresult")
+			Expect(err).To(BeNil(), "Fail to get chaosresult")
 		})
 	})
 

--- a/tests/openebs-target-network-loss_test.go
+++ b/tests/openebs-target-network-loss_test.go
@@ -159,32 +159,18 @@ var _ = Describe("BDD of openebs target network loss experiment", func() {
 			Expect(err).To(BeNil(), "Fail to get the runner pod")
 			Expect(string(runner.Status.Phase)).To(Equal("Running"))
 
-			//Fetch job pod name
-			By("Fetch Job pod name")
+			//Waiting for experiment job to get completed
+			//Also print the logs of the job
+			By("Waiting for job completion")
 			jobPodLogs, err := utils.JobLogs(experimentName, engineName, client)
 			Expect(jobPodLogs).To(Equal(0), "Fail to print the logs of the experiment")
 			Expect(err).To(BeNil(), "Fail to print the logs of the experiment")
 
-			//Running it for infinite time (say 3000 * 10)
-			//The Gitlab job will quit if it takes more time than default time (10 min)
-			By("Wait for engine to come in Succeeded sate")
-			runnerAfter, err := client.CoreV1().Pods(chaosTypes.ChaosNamespace).Get(engineName+"-runner", metav1.GetOptions{})
-			for i := 0; i < 3000; i++ {
-				if string(runnerAfter.Status.Phase) != "Succeeded" {
-					time.Sleep(10 * time.Second)
-					runnerAfter, _ = client.CoreV1().Pods(chaosTypes.ChaosNamespace).Get(engineName+"-runner", metav1.GetOptions{})
-					fmt.Printf("Currently, the runner pod is in %v State, Please Wait ...\n", runnerAfter.Status.Phase)
-				} else {
-					break
-				}
-			}
-			Expect(err).To(BeNil())
-			Expect(string(runnerAfter.Status.Phase)).To(Equal("Succeeded"))
-
 			//Checking the chaosresult
 			By("Checking the chaosresult")
-			app, _ := clientSet.ChaosResults(chaosTypes.ChaosNamespace).Get("engine5-openebs-target-network-loss", metav1.GetOptions{})
-			Expect(string(app.Spec.ExperimentStatus.Verdict)).To(Equal("Pass"), "Verdict is not pass chaosresult")
+			app, err := clientSet.ChaosResults(chaosTypes.ChaosNamespace).Get(engineName+"-"+experimentName, metav1.GetOptions{})
+			Expect(string(app.Status.ExperimentStatus.Verdict)).To(Equal("Pass"), "Verdict is not pass chaosresult")
+			Expect(err).To(BeNil(), "Fail to get chaosresult")
 		})
 	})
 

--- a/tests/openebs-target-pod-failure_test.go
+++ b/tests/openebs-target-pod-failure_test.go
@@ -93,7 +93,7 @@ var _ = Describe("BDD of openebs target pod failure experiment", func() {
 
 		It("Should check for creation of runner pod", func() {
 
-      //Getting the Sum of Resource Version and storing PodIP before Chaos
+			//Getting the Sum of Resource Version and storing PodIP before Chaos
 			target, err := client.CoreV1().Pods(chaosTypes.TargetPodNs).List(metav1.ListOptions{LabelSelector: chaosTypes.TargetPodLabels})
 			Expect(err).To(BeNil(), "fail to get target pods")
 			for i, podSpec := range target.Items {
@@ -185,32 +185,18 @@ var _ = Describe("BDD of openebs target pod failure experiment", func() {
 			Expect(err).To(BeNil(), "Fail to get the runner pod")
 			Expect(string(runner.Status.Phase)).To(Equal("Running"))
 
-			//Fetch job pod name
-			By("Fetch Job pod name")
+			//Waiting for experiment job to get completed
+			//Also print the logs of the job
+			By("Waiting for job completion")
 			jobPodLogs, err := utils.JobLogs(experimentName, engineName, client)
 			Expect(jobPodLogs).To(Equal(0), "Fail to print the logs of the experiment")
 			Expect(err).To(BeNil(), "Fail to print the logs of the experiment")
 
-			//Running it for infinite time (say 3000 * 10)
-			//The Gitlab job will quit if it takes more time than default time (10 min)
-			By("Wait for engine to come in Succeeded sate")
-			runnerAfter, err := client.CoreV1().Pods(chaosTypes.ChaosNamespace).Get(engineName+"-runner", metav1.GetOptions{})
-			for i := 0; i < 3000; i++ {
-				if string(runnerAfter.Status.Phase) != "Succeeded" {
-					time.Sleep(10 * time.Second)
-					runnerAfter, _ = client.CoreV1().Pods(chaosTypes.ChaosNamespace).Get(engineName+"-runner", metav1.GetOptions{})
-					fmt.Printf("Currently, the runner pod is in %v State, Please Wait ...\n", runnerAfter.Status.Phase)
-				} else {
-					break
-				}
-			}
-			Expect(err).To(BeNil())
-			Expect(string(runnerAfter.Status.Phase)).To(Equal("Succeeded"))
-
 			//Checking the chaosresult
 			By("Checking the chaosresult")
-			app, _ := clientSet.ChaosResults(chaosTypes.ChaosNamespace).Get("engine6-openebs-target-pod-failure", metav1.GetOptions{})
+			app, err := clientSet.ChaosResults(chaosTypes.ChaosNamespace).Get(engineName+"-"+experimentName, metav1.GetOptions{})
 			Expect(string(app.Spec.ExperimentStatus.Verdict)).To(Equal("Pass"), "Verdict is not pass chaosresult")
+			Expect(err).To(BeNil(), "Fail to get chaosresult")
 		})
 	})
 

--- a/tests/openebs-target-pod-failure_test.go
+++ b/tests/openebs-target-pod-failure_test.go
@@ -195,7 +195,7 @@ var _ = Describe("BDD of openebs target pod failure experiment", func() {
 			//Checking the chaosresult
 			By("Checking the chaosresult")
 			app, err := clientSet.ChaosResults(chaosTypes.ChaosNamespace).Get(engineName+"-"+experimentName, metav1.GetOptions{})
-			Expect(string(app.Spec.ExperimentStatus.Verdict)).To(Equal("Pass"), "Verdict is not pass chaosresult")
+			Expect(string(app.Status.ExperimentStatus.Verdict)).To(Equal("Pass"), "Verdict is not pass chaosresult")
 			Expect(err).To(BeNil(), "Fail to get chaosresult")
 		})
 	})


### PR DESCRIPTION
Signed-off-by: Udit Gaurav <uditgaurav@gmail.com>

**_This PR is for:_**

- Fixing the chaosengine and chaosrunner A/C to the latest changes

- The latest changes mentioned above is 
   - Automatically deletion of runner pod once it gets completes
   - Removing status from subresources