### PR TITLE
update(experiments): Rename the generic category to kubernetes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,7 +3,7 @@ stages:
   - setup
   - install
   - deploy
-  - generic-experiment
+  - kubernetes-experiment
   - infra-experiment
   - push
   - app-cleanup
@@ -96,7 +96,7 @@ pod-delete:
 
   when: always
   extends: .before_script_template
-  stage: generic-experiment
+  stage: kubernetes-experiment
   tags:
     - litmus-build
   script:
@@ -111,7 +111,7 @@ container-kill:
 
   when: always
   extends: .before_script_template
-  stage: generic-experiment
+  stage: kubernetes-experiment
   tags:
     - litmus-build
   script:
@@ -126,7 +126,7 @@ pod-network-latency:
 
   when: always
   extends: .before_script_template
-  stage: generic-experiment
+  stage: kubernetes-experiment
   tags:
     - litmus-build
   script:
@@ -141,7 +141,7 @@ pod-network-loss:
 
   when: always
   extends: .before_script_template
-  stage: generic-experiment
+  stage: kubernetes-experiment
   tags:
     - litmus-build
   script:
@@ -156,7 +156,7 @@ pod-network-corruption:
 
   when: always
   extends: .before_script_template
-  stage: generic-experiment
+  stage: kubernetes-experiment
   tags:
     - litmus-build
   script:
@@ -171,7 +171,7 @@ pod-cpu-hog:
 
   when: always
   extends: .before_script_template
-  stage: generic-experiment
+  stage: kubernetes-experiment
   tags:
     - litmus-build
   script:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## litmus-e2e
-This repository contains the Gitlab e2e pipeline with BDD and other positive and negative test cases for Generic experiments of litmus. An auxiliary application is deployed in the scope of different scenarios and the chaos is performed on that application then in the cleanup stage it is removed successfully.
+This repository contains the Gitlab e2e pipeline with BDD and other positive and negative test cases for Kubernetes experiments of litmus. An auxiliary application is deployed in the scope of different scenarios and the chaos is performed on that application then in the cleanup stage it is removed successfully.
 # Here are the different stages of the Gitlab pipeline:
 
 <table style="width:100%">
@@ -20,7 +20,7 @@ This repository contains the Gitlab e2e pipeline with BDD and other positive and
     <td>This is the application deployment stage. The application under chaos is deployed and the liveness test for the application is also performed in this stage.</td>
   </tr>
     <tr>
-    <td>Generic-experiment</td>
+    <td>kubernetes-experiment</td>
     <td>This stage includes the creation of experiments,engine and positive and negative test cases for the experiments.</td>
   </tr>
     <tr>

--- a/tests/container-kill_test.go
+++ b/tests/container-kill_test.go
@@ -88,7 +88,7 @@ var _ = Describe("BDD of pod-delete experiment", func() {
 		It("Should check for creation of runner pod", func() {
 
 			//Installing RBAC for the experiment
-			rbacPath := "https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/container-kill/rbac.yaml"
+			rbacPath := "https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/kubernetes/container-kill/rbac.yaml"
 			installrbac, err := utils.InstallRbac(rbacPath, experimentName, client)
 			Expect(installrbac).To(Equal(0), "Fail to create rbac file")
 			Expect(err).To(BeNil(), "Fail to create RBAC")
@@ -96,7 +96,7 @@ var _ = Describe("BDD of pod-delete experiment", func() {
 
 			//Creating Chaos-Experiment
 			By("Creating Experiment")
-			err = exec.Command("kubectl", "apply", "-f", "https://hub.litmuschaos.io/api/chaos?file=charts/generic/container-kill/experiment.yaml", "-n", chaosTypes.ChaosNamespace).Run()
+			err = exec.Command("kubectl", "apply", "-f", "https://hub.litmuschaos.io/api/chaos?file=charts/kubernetes/container-kill/experiment.yaml", "-n", chaosTypes.ChaosNamespace).Run()
 			Expect(err).To(BeNil(), "fail to create chaos experiment")
 			if err != nil {
 				fmt.Println(err)
@@ -107,7 +107,7 @@ var _ = Describe("BDD of pod-delete experiment", func() {
 			//Installing chaos engine for the experiment
 			//Fetching engine file
 			By("Fetching engine file for the experiment")
-			err = exec.Command("wget", "-O", experimentName+"-ce.yaml", "https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/container-kill/engine.yaml").Run()
+			err = exec.Command("wget", "-O", experimentName+"-ce.yaml", "https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/kubernetes/container-kill/engine.yaml").Run()
 			Expect(err).To(BeNil(), "Fail to fetch engine file")
 			//Modify chaos engine spec
 			//Modify Namespace,Name,AppNs,AppLabel of the engine

--- a/tests/disk-fill_test.go
+++ b/tests/disk-fill_test.go
@@ -88,7 +88,7 @@ var _ = Describe("BDD of disk-fill experiment", func() {
 		It("Should check for creation of runner pod", func() {
 
 			//Installing RBAC for the experiment
-			rbacPath := "https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/disk-fill/rbac.yaml"
+			rbacPath := "https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/kubernetes/disk-fill/rbac.yaml"
 			installrbac, err := utils.InstallRbac(rbacPath, experimentName, client)
 			Expect(installrbac).To(Equal(0), "Fail to create rbac file")
 			Expect(err).To(BeNil(), "Fail to create RBAC")
@@ -96,7 +96,7 @@ var _ = Describe("BDD of disk-fill experiment", func() {
 
 			//Creating Chaos-Experiment
 			By("Creating Experiment")
-			err = exec.Command("kubectl", "apply", "-f", "https://hub.litmuschaos.io/api/chaos?file=charts/generic/disk-fill/experiment.yaml", "-n", chaosTypes.ChaosNamespace).Run()
+			err = exec.Command("kubectl", "apply", "-f", "https://hub.litmuschaos.io/api/chaos?file=charts/kubernetes/disk-fill/experiment.yaml", "-n", chaosTypes.ChaosNamespace).Run()
 			Expect(err).To(BeNil(), "fail to create chaos experiment")
 			if err != nil {
 				fmt.Println(err)
@@ -107,7 +107,7 @@ var _ = Describe("BDD of disk-fill experiment", func() {
 			//Installing chaos engine for the experiment
 			//Fetching engine file
 			By("Fetching engine file for the experiment")
-			err = exec.Command("wget", "-O", experimentName+"-ce.yaml", "https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/disk-fill/engine.yaml").Run()
+			err = exec.Command("wget", "-O", experimentName+"-ce.yaml", "https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/kubernetes/disk-fill/engine.yaml").Run()
 			Expect(err).To(BeNil(), "Fail to fetch engine file")
 			//Modify chaos engine spec
 			//Modify Namespace,Name,AppNs,AppLabel of the engine

--- a/tests/node-cpu-hog_test.go
+++ b/tests/node-cpu-hog_test.go
@@ -88,7 +88,7 @@ var _ = Describe("BDD of node-cpu-hog experiment", func() {
 		It("Should check for creation of runner pod", func() {
 
 			//Installing RBAC for the experiment
-			rbacPath := "https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/node-cpu-hog/rbac.yaml"
+			rbacPath := "https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/kubernetes/node-cpu-hog/rbac.yaml"
 			installrbac, err := utils.InstallRbac(rbacPath, experimentName, client)
 			Expect(installrbac).To(Equal(0), "Fail to create rbac file")
 			Expect(err).To(BeNil(), "Fail to create RBAC")
@@ -96,7 +96,7 @@ var _ = Describe("BDD of node-cpu-hog experiment", func() {
 
 			//Creating Chaos-Experiment
 			By("Creating Experiment")
-			err = exec.Command("kubectl", "apply", "-f", "https://hub.litmuschaos.io/api/chaos?file=charts/generic/node-cpu-hog/experiment.yaml", "-n", chaosTypes.ChaosNamespace).Run()
+			err = exec.Command("kubectl", "apply", "-f", "https://hub.litmuschaos.io/api/chaos?file=charts/kubernetes/node-cpu-hog/experiment.yaml", "-n", chaosTypes.ChaosNamespace).Run()
 			Expect(err).To(BeNil(), "fail to create chaos experiment")
 			if err != nil {
 				fmt.Println(err)
@@ -107,7 +107,7 @@ var _ = Describe("BDD of node-cpu-hog experiment", func() {
 			//Installing chaos engine for the experiment
 			//Fetching engine fileengine6
 			By("Fetching engine file for the experiment")
-			err = exec.Command("wget", "-O", experimentName+"-ce.yaml", "https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/node-cpu-hog/engine.yaml").Run()
+			err = exec.Command("wget", "-O", experimentName+"-ce.yaml", "https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/kubernetes/node-cpu-hog/engine.yaml").Run()
 			Expect(err).To(BeNil(), "Fail to fetch engine file")
 			//Modify chaos engine spec
 			//Modify Namespace,Name,AppNs,AppLabel of the engine

--- a/tests/node-drain_test.go
+++ b/tests/node-drain_test.go
@@ -101,7 +101,7 @@ var _ = Describe("BDD of node-drain experiment", func() {
 			}
 
 			//Installing RBAC for the experiment
-			rbacPath := "https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/node-drain/rbac.yaml"
+			rbacPath := "https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/kubernetes/node-drain/rbac.yaml"
 			installrbac, err := utils.InstallRbac(rbacPath, experimentName, client)
 			Expect(installrbac).To(Equal(0), "Fail to create rbac file")
 			Expect(err).To(BeNil(), "Fail to create RBAC")
@@ -109,7 +109,7 @@ var _ = Describe("BDD of node-drain experiment", func() {
 
 			//Creating Chaos-Experiment
 			By("Creating Experiment")
-			err = exec.Command("kubectl", "apply", "-f", "https://hub.litmuschaos.io/api/chaos?file=charts/generic/node-drain/experiment.yaml", "-n", chaosTypes.ChaosNamespace).Run()
+			err = exec.Command("kubectl", "apply", "-f", "https://hub.litmuschaos.io/api/chaos?file=charts/kubernetes/node-drain/experiment.yaml", "-n", chaosTypes.ChaosNamespace).Run()
 			Expect(err).To(BeNil(), "fail to create chaos experiment")
 			if err != nil {
 				fmt.Println(err)
@@ -120,7 +120,7 @@ var _ = Describe("BDD of node-drain experiment", func() {
 			//Installing chaos engine for the experiment
 			//Fetching engine file
 			By("Fetching engine file for the experiment")
-			err = exec.Command("wget", "-O", experimentName+"-ce.yaml", "https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/node-drain/engine.yaml").Run()
+			err = exec.Command("wget", "-O", experimentName+"-ce.yaml", "https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/kubernetes/node-drain/engine.yaml").Run()
 			Expect(err).To(BeNil(), "Fail to fetch engine file")
 			//Modify chaos engine spec
 			//Modify Namespace,Name,AppNs,AppLabel of the engine

--- a/tests/node-memory-hog_test.go
+++ b/tests/node-memory-hog_test.go
@@ -88,7 +88,7 @@ var _ = Describe("BDD of node-memory-hog experiment", func() {
 		It("Should check for creation of runner pod", func() {
 
 			//Installing RBAC for the experiment
-			rbacPath := "https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/node-memory-hog/rbac.yaml"
+			rbacPath := "https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/kubernetes/node-memory-hog/rbac.yaml"
 			installrbac, err := utils.InstallRbac(rbacPath, experimentName, client)
 			Expect(installrbac).To(Equal(0), "Fail to create rbac file")
 			Expect(err).To(BeNil(), "Fail to create RBAC")
@@ -96,7 +96,7 @@ var _ = Describe("BDD of node-memory-hog experiment", func() {
 
 			//Creating Chaos-Experiment
 			By("Creating Experiment")
-			err = exec.Command("kubectl", "apply", "-f", "https://hub.litmuschaos.io/api/chaos?file=charts/generic/node-memory-hog/experiment.yaml", "-n", chaosTypes.ChaosNamespace).Run()
+			err = exec.Command("kubectl", "apply", "-f", "https://hub.litmuschaos.io/api/chaos?file=charts/kubernetes/node-memory-hog/experiment.yaml", "-n", chaosTypes.ChaosNamespace).Run()
 			Expect(err).To(BeNil(), "fail to create chaos experiment")
 			if err != nil {
 				fmt.Println(err)
@@ -107,7 +107,7 @@ var _ = Describe("BDD of node-memory-hog experiment", func() {
 			//Installing chaos engine for the experiment
 			//Fetching engine file
 			By("Fetching engine file for the experiment")
-			err = exec.Command("wget", "-O", experimentName+"-ce.yaml", "https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/node-memory-hog/engine.yaml").Run()
+			err = exec.Command("wget", "-O", experimentName+"-ce.yaml", "https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/kubernetes/node-memory-hog/engine.yaml").Run()
 			Expect(err).To(BeNil(), "Fail to fetch engine file")
 			//Modify chaos engine spec
 			//Modify Namespace,Name,AppNs,AppLabel of the engine

--- a/tests/pod-cpu-hog_test.go
+++ b/tests/pod-cpu-hog_test.go
@@ -88,7 +88,7 @@ var _ = Describe("BDD of pod-cpu-hog experiment", func() {
 		It("Should check for creation of runner pod", func() {
 
 			//Installing RBAC for the experiment
-			rbacPath := "https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/pod-cpu-hog/rbac.yaml"
+			rbacPath := "https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/kubernetes/pod-cpu-hog/rbac.yaml"
 			installrbac, err := utils.InstallRbac(rbacPath, experimentName, client)
 			Expect(installrbac).To(Equal(0), "Fail to create rbac file")
 			Expect(err).To(BeNil(), "Fail to create RBAC")
@@ -96,7 +96,7 @@ var _ = Describe("BDD of pod-cpu-hog experiment", func() {
 
 			//Creating Chaos-Experiment
 			By("Creating Experiment")
-			err = exec.Command("kubectl", "apply", "-f", "https://hub.litmuschaos.io/api/chaos?file=charts/generic/pod-cpu-hog/experiment.yaml", "-n", chaosTypes.ChaosNamespace).Run()
+			err = exec.Command("kubectl", "apply", "-f", "https://hub.litmuschaos.io/api/chaos?file=charts/kubernetes/pod-cpu-hog/experiment.yaml", "-n", chaosTypes.ChaosNamespace).Run()
 			Expect(err).To(BeNil(), "fail to create chaos experiment")
 			if err != nil {
 				fmt.Println(err)
@@ -107,7 +107,7 @@ var _ = Describe("BDD of pod-cpu-hog experiment", func() {
 			//Installing chaos engine for the experiment
 			//Fetching engine file
 			By("Fetching engine file for the experiment")
-			err = exec.Command("wget", "-O", experimentName+"-ce.yaml", "https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/pod-cpu-hog/engine.yaml").Run()
+			err = exec.Command("wget", "-O", experimentName+"-ce.yaml", "https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/kubernetes/pod-cpu-hog/engine.yaml").Run()
 			Expect(err).To(BeNil(), "Fail to fetch engine file")
 			//Modify chaos engine spec
 			//Modify Namespace,Name,AppNs,AppLabel of the engine

--- a/tests/pod-delete_test.go
+++ b/tests/pod-delete_test.go
@@ -88,7 +88,7 @@ var _ = Describe("BDD of pod-delete experiment", func() {
 		It("Should check for creation of runner pod", func() {
 
 			//Installing RBAC for the experiment
-			rbacPath := "https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/pod-delete/rbac.yaml"
+			rbacPath := "https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/kubernetes/pod-delete/rbac.yaml"
 			installrbac, err := utils.InstallRbac(rbacPath, experimentName, client)
 			Expect(installrbac).To(Equal(0), "Fail to create rbac file")
 			Expect(err).To(BeNil(), "Fail to create RBAC")
@@ -96,7 +96,7 @@ var _ = Describe("BDD of pod-delete experiment", func() {
 
 			//Creating Chaos-Experiment
 			By("Creating Experiment")
-			err = exec.Command("kubectl", "apply", "-f", "https://hub.litmuschaos.io/api/chaos?file=charts/generic/pod-delete/experiment.yaml", "-n", chaosTypes.ChaosNamespace).Run()
+			err = exec.Command("kubectl", "apply", "-f", "https://hub.litmuschaos.io/api/chaos?file=charts/kubernetes/pod-delete/experiment.yaml", "-n", chaosTypes.ChaosNamespace).Run()
 			Expect(err).To(BeNil(), "fail to create chaos experiment")
 			if err != nil {
 				fmt.Println(err)
@@ -106,7 +106,7 @@ var _ = Describe("BDD of pod-delete experiment", func() {
 			//Installing chaos engine for the experiment
 			//Fetching engine file
 			By("Fetching engine file for the experiment")
-			err = exec.Command("wget", "-O", experimentName+"-ce.yaml", "https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/pod-delete/engine.yaml").Run()
+			err = exec.Command("wget", "-O", experimentName+"-ce.yaml", "https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/kubernetes/pod-delete/engine.yaml").Run()
 			Expect(err).To(BeNil(), "Fail to fetch engine file")
 			//Modify chaos engine spec
 			//Modify Namespace,Name,AppNs,AppLabel of the engine

--- a/tests/pod-network-corruption_test.go
+++ b/tests/pod-network-corruption_test.go
@@ -86,7 +86,7 @@ var _ = Describe("BDD of pod-delete experiment", func() {
 		It("Should check for creation of runner pod", func() {
 
 			//Installing RBAC for the experiment
-			rbacPath := "https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/pod-network-corruption/rbac.yaml"
+			rbacPath := "https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/kubernetes/pod-network-corruption/rbac.yaml"
 			installrbac, err := utils.InstallRbac(rbacPath, experimentName, client)
 			Expect(installrbac).To(Equal(0), "Fail to create rbac file")
 			Expect(err).To(BeNil(), "Fail to create RBAC")
@@ -94,7 +94,7 @@ var _ = Describe("BDD of pod-delete experiment", func() {
 
 			//Creating Chaos-Experiment
 			By("Creating Experiment")
-			err = exec.Command("kubectl", "apply", "-f", "https://hub.litmuschaos.io/api/chaos?file=charts/generic/pod-network-corruption/experiment.yaml", "-n", chaosTypes.ChaosNamespace).Run()
+			err = exec.Command("kubectl", "apply", "-f", "https://hub.litmuschaos.io/api/chaos?file=charts/kubernetes/pod-network-corruption/experiment.yaml", "-n", chaosTypes.ChaosNamespace).Run()
 			Expect(err).To(BeNil(), "fail to create chaos experiment")
 			if err != nil {
 				fmt.Println(err)
@@ -105,7 +105,7 @@ var _ = Describe("BDD of pod-delete experiment", func() {
 			//Installing chaos engine for the experiment
 			//Fetching engine file
 			By("Fetching engine file for the experiment")
-			err = exec.Command("wget", "-O", experimentName+"-ce.yaml", "https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/pod-network-corruption/engine.yaml").Run()
+			err = exec.Command("wget", "-O", experimentName+"-ce.yaml", "https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/kubernetes/pod-network-corruption/engine.yaml").Run()
 			Expect(err).To(BeNil(), "Fail to fetch engine file")
 			//Modify chaos engine spec
 			//Modify Namespace,Name,AppNs,AppLabel of the engine

--- a/tests/pod-network-latency_test.go
+++ b/tests/pod-network-latency_test.go
@@ -88,7 +88,7 @@ var _ = Describe("BDD of pod-delete experiment", func() {
 		It("Should check for creation of runner pod", func() {
 
 			//Installing RBAC for the experiment
-			rbacPath := "https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/pod-network-latency/rbac.yaml"
+			rbacPath := "https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/kubernetes/pod-network-latency/rbac.yaml"
 			installrbac, err := utils.InstallRbac(rbacPath, experimentName, client)
 			Expect(installrbac).To(Equal(0), "Fail to create rbac file")
 			Expect(err).To(BeNil(), "Fail to create RBAC")
@@ -96,7 +96,7 @@ var _ = Describe("BDD of pod-delete experiment", func() {
 
 			//Creating Chaos-Experiment
 			By("Creating Experiment")
-			err = exec.Command("kubectl", "apply", "-f", "https://hub.litmuschaos.io/api/chaos?file=charts/generic/pod-network-latency/experiment.yaml", "-n", chaosTypes.ChaosNamespace).Run()
+			err = exec.Command("kubectl", "apply", "-f", "https://hub.litmuschaos.io/api/chaos?file=charts/kubernetes/pod-network-latency/experiment.yaml", "-n", chaosTypes.ChaosNamespace).Run()
 			Expect(err).To(BeNil(), "fail to create chaos experiment")
 			if err != nil {
 				fmt.Println(err)
@@ -107,7 +107,7 @@ var _ = Describe("BDD of pod-delete experiment", func() {
 			//Installing chaos engine for the experiment
 			//Fetching engine file
 			By("Fetching engine file for the experiment")
-			err = exec.Command("wget", "-O", experimentName+"-ce.yaml", "https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/pod-network-latency/engine.yaml").Run()
+			err = exec.Command("wget", "-O", experimentName+"-ce.yaml", "https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/kubernetes/pod-network-latency/engine.yaml").Run()
 			Expect(err).To(BeNil(), "Fail to fetch engine file")
 			//Modify chaos engine spec
 			//Modify Namespace,Name,AppNs,AppLabel of the engine

--- a/tests/pod-network-loss_test.go
+++ b/tests/pod-network-loss_test.go
@@ -88,7 +88,7 @@ var _ = Describe("BDD of pod-delete experiment", func() {
 		It("Should check for creation of runner pod", func() {
 
 			//Installing RBAC for the experiment
-			rbacPath := "https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/pod-network-loss/rbac.yaml"
+			rbacPath := "https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/kubernetes/pod-network-loss/rbac.yaml"
 			installrbac, err := utils.InstallRbac(rbacPath, experimentName, client)
 			Expect(installrbac).To(Equal(0), "Fail to create rbac file")
 			Expect(err).To(BeNil(), "Fail to create RBAC")
@@ -96,7 +96,7 @@ var _ = Describe("BDD of pod-delete experiment", func() {
 
 			//Creating Chaos-Experiment
 			By("Creating Experiment")
-			err = exec.Command("kubectl", "apply", "-f", "https://hub.litmuschaos.io/api/chaos?file=charts/generic/pod-network-loss/experiment.yaml", "-n", chaosTypes.ChaosNamespace).Run()
+			err = exec.Command("kubectl", "apply", "-f", "https://hub.litmuschaos.io/api/chaos?file=charts/kubernetes/pod-network-loss/experiment.yaml", "-n", chaosTypes.ChaosNamespace).Run()
 			Expect(err).To(BeNil(), "fail to create chaos experiment")
 			if err != nil {
 				fmt.Println(err)
@@ -107,7 +107,7 @@ var _ = Describe("BDD of pod-delete experiment", func() {
 			//Installing chaos engine for the experiment
 			//Fetching engine file
 			By("Fetching engine file for the experiment")
-			err = exec.Command("wget", "-O", experimentName+"-ce.yaml", "https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/pod-network-loss/engine.yaml").Run()
+			err = exec.Command("wget", "-O", experimentName+"-ce.yaml", "https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/kubernetes/pod-network-loss/engine.yaml").Run()
 			Expect(err).To(BeNil(), "Fail to fetch engine file")
 			//Modify chaos engine spec
 			//Modify Namespace,Name,AppNs,AppLabel of the engine


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

- Rename the generic category to kubernetes