### PR TITLE
(feat): Using custom Images of different components of litmus for running pipelines

### DIFF
--- a/tests/container-kill_test.go
+++ b/tests/container-kill_test.go
@@ -27,7 +27,6 @@ var (
 	client         *kubernetes.Clientset
 	clientSet      *chaosClient.LitmuschaosV1alpha1Client
 	err            error
-	image_tag      = os.Getenv("IMAGE_TAG")
 	experimentName = "container-kill"
 	engineName     = "engine1"
 )
@@ -99,11 +98,11 @@ var _ = Describe("BDD of pod-delete experiment", func() {
 			By("Creating Experiment")
 			err = exec.Command("wget", "-O", "container-kill.yaml", "https://hub.litmuschaos.io/api/chaos?file=charts/generic/container-kill/experiment.yaml").Run()
 			Expect(err).To(BeNil(), "fail get chaos experiment")
-			err = exec.Command("sed", "-i", `s/ansible-runner:latest/ansible-runner:`+image_tag+`/g`, "container-kill.yaml").Run()
+			err = exec.Command("sed", "-i", `s/litmuschaos\/ansible-runner:latest/`+chaosTypes.ExperimentRepoName+`\/`+chaosTypes.ExperimentImage+`:`+chaosTypes.ExperimentImageTag+`/g`, "container-kill.yaml").Run()
 			Expect(err).To(BeNil(), "fail to edit chaos experiment yaml")
 			err = exec.Command("kubectl", "apply", "-f", "container-kill.yaml", "-n", chaosTypes.ChaosNamespace).Run()
 			Expect(err).To(BeNil(), "fail to create chaos experiment")
-			fmt.Println("Chaos Experiment Created Successfully")
+			fmt.Println("Chaos Experiment Created Successfully with image =", chaosTypes.ExperimentRepoName, "/", chaosTypes.ExperimentImage, ":", chaosTypes.ExperimentImageTag)
 
 			//Installing chaos engine for the experiment
 			//Fetching engine file

--- a/tests/disk-fill_test.go
+++ b/tests/disk-fill_test.go
@@ -27,7 +27,6 @@ var (
 	client         *kubernetes.Clientset
 	clientSet      *chaosClient.LitmuschaosV1alpha1Client
 	err            error
-	image_tag      = os.Getenv("IMAGE_TAG")
 	experimentName = "disk-fill"
 	engineName     = "engine8"
 )
@@ -99,11 +98,11 @@ var _ = Describe("BDD of disk-fill experiment", func() {
 			By("Creating Experiment")
 			err = exec.Command("wget", "-O", "disk-fill.yaml", "https://hub.litmuschaos.io/api/chaos?file=charts/generic/disk-fill/experiment.yaml").Run()
 			Expect(err).To(BeNil(), "fail get chaos experiment")
-			err = exec.Command("sed", "-i", `s/ansible-runner:latest/ansible-runner:`+image_tag+`/g`, "disk-fill.yaml").Run()
+			err = exec.Command("sed", "-i", `s/litmuschaos\/ansible-runner:latest/`+chaosTypes.ExperimentRepoName+`\/`+chaosTypes.ExperimentImage+`:`+chaosTypes.ExperimentImageTag+`/g`, "disk-fill.yaml").Run()
 			Expect(err).To(BeNil(), "fail to edit chaos experiment yaml")
 			err = exec.Command("kubectl", "apply", "-f", "disk-fill.yaml", "-n", chaosTypes.ChaosNamespace).Run()
 			Expect(err).To(BeNil(), "fail to create chaos experiment")
-			fmt.Println("Chaos Experiment Created Successfully")
+			fmt.Println("Chaos Experiment Created Successfully with image =", chaosTypes.ExperimentRepoName, "/", chaosTypes.ExperimentImage, ":", chaosTypes.ExperimentImageTag)
 
 			//Installing chaos engine for the experiment
 			//Fetching engine file

--- a/tests/install-litmus_test.go
+++ b/tests/install-litmus_test.go
@@ -106,7 +106,7 @@ var _ = Describe("BDD of litmus installation", func() {
 			err = exec.Command("kubectl", "apply", "-f", "openebs-operator.yml").Run()
 			Expect(err).To(BeNil(), "Failed to create chaos operator")
 
-			fmt.Println("Runner Image:", chaosTypes.RunnerRepoName, "/", chaosTypes.RunnerRepoName, ":", chaosTypes.RunnerImageTag)
+			fmt.Println("Runner Image:", chaosTypes.RunnerRepoName, "/", chaosTypes.RunnerImage, ":", chaosTypes.RunnerImageTag)
 
 			//Checking the status of operator
 			operator, _ := client.AppsV1().Deployments(chaosTypes.ChaosNamespace).Get("litmus", metav1.GetOptions{})

--- a/tests/install-litmus_test.go
+++ b/tests/install-litmus_test.go
@@ -99,7 +99,7 @@ var _ = Describe("BDD of litmus installation", func() {
 			Expect(err).To(BeNil(), "Failed to Fetch operator manifest")
 			err = exec.Command("sed", "-i",
 				`s/litmuschaos\/chaos-operator:ci/`+chaosTypes.OperatorRepoName+`\/`+chaosTypes.OperatorImage+`:`+chaosTypes.OperatorImageTag+`/g;
-				 s/#  value: "litmuschaos\/chaos-runner:ci"/  value: "`+chaosTypes.RunnerRepoName+`\/`+chaosTypes.RunnerRepoName+`:`+chaosTypes.RunnerImageTag+`"/g;
+				 s/#  value: "litmuschaos\/chaos-runner:ci"/  value: "`+chaosTypes.RunnerRepoName+`\/`+chaosTypes.RunnerImage+`:`+chaosTypes.RunnerImageTag+`"/g;
 			     s/#- name: CHAOS_RUNNER_IMAGE/- name: CHAOS_RUNNER_IMAGE/g`,
 				"openebs-operator.yml").Run()
 			Expect(err).To(BeNil(), "Failed to edit operator manifest")

--- a/tests/install-litmus_test.go
+++ b/tests/install-litmus_test.go
@@ -27,7 +27,6 @@ var (
 	client     *kubernetes.Clientset
 	clientSet  *chaosClient.LitmuschaosV1alpha1Client
 	err        error
-	image_tag  = os.Getenv("IMAGE_TAG")
 )
 
 func TestChaos(t *testing.T) {
@@ -92,23 +91,22 @@ var _ = Describe("BDD of litmus installation", func() {
 			}
 
 			fmt.Println("rbac Installed successfully")
-			fmt.Printf("Installing operator with image tag: %v \n", image_tag)
+			fmt.Println("Installing Operator with image:", chaosTypes.OperatorRepoName, "/", chaosTypes.OperatorImage, ":", chaosTypes.OperatorImageTag)
 
 			//Installing operator
 			By("Installing operator")
 			err = exec.Command("wget", "-O", "openebs-operator.yml", "https://raw.githubusercontent.com/litmuschaos/chaos-operator/master/deploy/operator.yaml").Run()
 			Expect(err).To(BeNil(), "Failed to Fetch operator manifest")
 			err = exec.Command("sed", "-i",
-				`s/chaos-operator:ci/chaos-operator:`+image_tag+`/g;
-				 s/#  value: "litmuschaos\/chaos-runner:ci"/  value: "litmuschaos\/chaos-runner:`+image_tag+`"/g;
+				`s/litmuschaos\/chaos-operator:ci/`+chaosTypes.OperatorRepoName+`\/`+chaosTypes.OperatorImage+`:`+chaosTypes.OperatorImageTag+`/g;
+				 s/#  value: "litmuschaos\/chaos-runner:ci"/  value: "`+chaosTypes.RunnerRepoName+`\/`+chaosTypes.RunnerRepoName+`:`+chaosTypes.RunnerImageTag+`"/g;
 			     s/#- name: CHAOS_RUNNER_IMAGE/- name: CHAOS_RUNNER_IMAGE/g`,
 				"openebs-operator.yml").Run()
 			Expect(err).To(BeNil(), "Failed to edit operator manifest")
 			err = exec.Command("kubectl", "apply", "-f", "openebs-operator.yml").Run()
 			Expect(err).To(BeNil(), "Failed to create chaos operator")
-			if err != nil {
-				fmt.Println(err)
-			}
+
+			fmt.Println("Runner Image:", chaosTypes.RunnerRepoName, "/", chaosTypes.RunnerRepoName, ":", chaosTypes.RunnerImageTag)
 
 			//Checking the status of operator
 			operator, _ := client.AppsV1().Deployments(chaosTypes.ChaosNamespace).Get("litmus", metav1.GetOptions{})

--- a/tests/node-cpu-hog_test.go
+++ b/tests/node-cpu-hog_test.go
@@ -27,7 +27,6 @@ var (
 	client         *kubernetes.Clientset
 	clientSet      *chaosClient.LitmuschaosV1alpha1Client
 	err            error
-	image_tag      = os.Getenv("IMAGE_TAG")
 	experimentName = "node-cpu-hog"
 	engineName     = "engine6"
 )
@@ -99,11 +98,11 @@ var _ = Describe("BDD of node-cpu-hog experiment", func() {
 			By("Creating Experiment")
 			err = exec.Command("wget", "-O", "node-cpu-hog.yaml", "https://hub.litmuschaos.io/api/chaos?file=charts/generic/node-cpu-hog/experiment.yaml").Run()
 			Expect(err).To(BeNil(), "fail get chaos experiment")
-			err = exec.Command("sed", "-i", `s/ansible-runner:latest/ansible-runner:`+image_tag+`/g`, "node-cpu-hog.yaml").Run()
+			err = exec.Command("sed", "-i", `s/litmuschaos\/ansible-runner:latest/`+chaosTypes.ExperimentRepoName+`\/`+chaosTypes.ExperimentImage+`:`+chaosTypes.ExperimentImageTag+`/g`, "node-cpu-hog.yaml").Run()
 			Expect(err).To(BeNil(), "fail to edit chaos experiment yaml")
 			err = exec.Command("kubectl", "apply", "-f", "node-cpu-hog.yaml", "-n", chaosTypes.ChaosNamespace).Run()
 			Expect(err).To(BeNil(), "fail to create chaos experiment")
-			fmt.Println("Chaos Experiment Created Successfully")
+			fmt.Println("Chaos Experiment Created Successfully with image =", chaosTypes.ExperimentRepoName, "/", chaosTypes.ExperimentImage, ":", chaosTypes.ExperimentImageTag)
 
 			//Installing chaos engine for the experiment
 			//Fetching engine fileengine6

--- a/tests/node-drain_test.go
+++ b/tests/node-drain_test.go
@@ -27,7 +27,6 @@ var (
 	client         *kubernetes.Clientset
 	clientSet      *chaosClient.LitmuschaosV1alpha1Client
 	err            error
-	image_tag      = os.Getenv("IMAGE_TAG")
 	experimentName = "node-drain"
 	engineName     = "engine7"
 )
@@ -112,11 +111,11 @@ var _ = Describe("BDD of node-drain experiment", func() {
 			By("Creating Experiment")
 			err = exec.Command("wget", "-O", "node-drain.yaml", "https://hub.litmuschaos.io/api/chaos?file=charts/generic/node-drain/experiment.yaml").Run()
 			Expect(err).To(BeNil(), "fail get chaos experiment")
-			err = exec.Command("sed", "-i", `s/ansible-runner:latest/ansible-runner:`+image_tag+`/g`, "node-drain.yaml").Run()
+			err = exec.Command("sed", "-i", `s/litmuschaos\/ansible-runner:latest/`+chaosTypes.ExperimentRepoName+`\/`+chaosTypes.ExperimentImage+`:`+chaosTypes.ExperimentImageTag+`/g`, "node-drain.yaml").Run()
 			Expect(err).To(BeNil(), "fail to edit chaos experiment yaml")
 			err = exec.Command("kubectl", "apply", "-f", "node-drain.yaml", "-n", chaosTypes.ChaosNamespace).Run()
 			Expect(err).To(BeNil(), "fail to create chaos experiment")
-			fmt.Println("Chaos Experiment Created Successfully")
+			fmt.Println("Chaos Experiment Created Successfully with image =", chaosTypes.ExperimentRepoName, "/", chaosTypes.ExperimentImage, ":", chaosTypes.ExperimentImageTag)
 
 			//Installing chaos engine for the experiment
 			//Fetching engine file

--- a/tests/node-memory-hog_test.go
+++ b/tests/node-memory-hog_test.go
@@ -27,7 +27,6 @@ var (
 	client         *kubernetes.Clientset
 	clientSet      *chaosClient.LitmuschaosV1alpha1Client
 	err            error
-	image_tag      = os.Getenv("IMAGE_TAG")
 	experimentName = "node-memory-hog"
 	engineName     = "engine9"
 )
@@ -99,11 +98,11 @@ var _ = Describe("BDD of node-memory-hog experiment", func() {
 			By("Creating Experiment")
 			err = exec.Command("wget", "-O", "node-memory-hog.yaml", "https://hub.litmuschaos.io/api/chaos?file=charts/generic/node-memory-hog/experiment.yaml").Run()
 			Expect(err).To(BeNil(), "fail get chaos experiment")
-			err = exec.Command("sed", "-i", `s/ansible-runner:latest/ansible-runner:`+image_tag+`/g`, "node-memory-hog.yaml").Run()
+			err = exec.Command("sed", "-i", `s/litmuschaos\/ansible-runner:latest/`+chaosTypes.ExperimentRepoName+`\/`+chaosTypes.ExperimentImage+`:`+chaosTypes.ExperimentImageTag+`/g`, "node-memory-hog.yaml").Run()
 			Expect(err).To(BeNil(), "fail to edit chaos experiment yaml")
 			err = exec.Command("kubectl", "apply", "-f", "node-memory-hog.yaml", "-n", chaosTypes.ChaosNamespace).Run()
 			Expect(err).To(BeNil(), "fail to create chaos experiment")
-			fmt.Println("Chaos Experiment Created Successfully")
+			fmt.Println("Chaos Experiment Created Successfully with image =", chaosTypes.ExperimentRepoName, "/", chaosTypes.ExperimentImage, ":", chaosTypes.ExperimentImageTag)
 
 			//Installing chaos engine for the experiment
 			//Fetching engine file

--- a/tests/pod-cpu-hog_test.go
+++ b/tests/pod-cpu-hog_test.go
@@ -27,7 +27,6 @@ var (
 	client         *kubernetes.Clientset
 	clientSet      *chaosClient.LitmuschaosV1alpha1Client
 	err            error
-	image_tag      = os.Getenv("IMAGE_TAG")
 	experimentName = "pod-cpu-hog"
 	engineName     = "engine5"
 )
@@ -99,11 +98,11 @@ var _ = Describe("BDD of pod-cpu-hog experiment", func() {
 			By("Creating Experiment")
 			err = exec.Command("wget", "-O", "pod-cpu-hog.yaml", "https://hub.litmuschaos.io/api/chaos?file=charts/generic/pod-cpu-hog/experiment.yaml").Run()
 			Expect(err).To(BeNil(), "fail get chaos experiment")
-			err = exec.Command("sed", "-i", `s/ansible-runner:latest/ansible-runner:`+image_tag+`/g`, "pod-cpu-hog.yaml").Run()
+			err = exec.Command("sed", "-i", `s/litmuschaos\/ansible-runner:latest/`+chaosTypes.ExperimentRepoName+`\/`+chaosTypes.ExperimentImage+`:`+chaosTypes.ExperimentImageTag+`/g`, "pod-cpu-hog.yaml").Run()
 			Expect(err).To(BeNil(), "fail to edit chaos experiment yaml")
 			err = exec.Command("kubectl", "apply", "-f", "pod-cpu-hog.yaml", "-n", chaosTypes.ChaosNamespace).Run()
 			Expect(err).To(BeNil(), "fail to create chaos experiment")
-			fmt.Println("Chaos Experiment Created Successfully")
+			fmt.Println("Chaos Experiment Created Successfully with image =", chaosTypes.ExperimentRepoName, "/", chaosTypes.ExperimentImage, ":", chaosTypes.ExperimentImageTag)
 
 			//Installing chaos engine for the experiment
 			//Fetching engine file

--- a/tests/pod-delete_test.go
+++ b/tests/pod-delete_test.go
@@ -27,7 +27,6 @@ var (
 	client         *kubernetes.Clientset
 	clientSet      *chaosClient.LitmuschaosV1alpha1Client
 	err            error
-	image_tag      = os.Getenv("IMAGE_TAG")
 	experimentName = "pod-delete"
 	engineName     = "engine"
 )
@@ -99,11 +98,11 @@ var _ = Describe("BDD of pod-delete experiment", func() {
 			By("Creating Experiment")
 			err = exec.Command("wget", "-O", "pod-delete.yaml", "https://hub.litmuschaos.io/api/chaos?file=charts/generic/pod-delete/experiment.yaml").Run()
 			Expect(err).To(BeNil(), "fail get chaos experiment")
-			err = exec.Command("sed", "-i", `s/ansible-runner:latest/ansible-runner:`+image_tag+`/g`, "pod-delete.yaml").Run()
+			err = exec.Command("sed", "-i", `s/litmuschaos\/ansible-runner:latest/`+chaosTypes.ExperimentRepoName+`\/`+chaosTypes.ExperimentImage+`:`+chaosTypes.ExperimentImageTag+`/g`, "pod-delete.yaml").Run()
 			Expect(err).To(BeNil(), "fail to edit chaos experiment yaml")
 			err = exec.Command("kubectl", "apply", "-f", "pod-delete.yaml", "-n", chaosTypes.ChaosNamespace).Run()
 			Expect(err).To(BeNil(), "fail to create chaos experiment")
-			fmt.Println("Chaos Experiment Created Successfully")
+			fmt.Println("Chaos Experiment Created Successfully with image =", chaosTypes.ExperimentRepoName, "/", chaosTypes.ExperimentImage, ":", chaosTypes.ExperimentImageTag)
 
 			//Installing chaos engine for the experiment
 			//Fetching engine file

--- a/tests/pod-network-corruption_test.go
+++ b/tests/pod-network-corruption_test.go
@@ -27,7 +27,6 @@ var (
 	client         *kubernetes.Clientset
 	clientSet      *chaosClient.LitmuschaosV1alpha1Client
 	err            error
-	image_tag      = os.Getenv("IMAGE_TAG")
 	experimentName = "pod-network-corruption"
 	engineName     = "engine4"
 )
@@ -97,11 +96,11 @@ var _ = Describe("BDD of pod-delete experiment", func() {
 			By("Creating Experiment")
 			err = exec.Command("wget", "-O", "pod-network-corruption.yaml", "https://hub.litmuschaos.io/api/chaos?file=charts/generic/pod-network-corruption/experiment.yaml").Run()
 			Expect(err).To(BeNil(), "fail get chaos experiment")
-			err = exec.Command("sed", "-i", `s/ansible-runner:latest/ansible-runner:`+image_tag+`/g`, "pod-network-corruption.yaml").Run()
+			err = exec.Command("sed", "-i", `s/litmuschaos\/ansible-runner:latest/`+chaosTypes.ExperimentRepoName+`\/`+chaosTypes.ExperimentImage+`:`+chaosTypes.ExperimentImageTag+`/g`, "pod-network-corruption.yaml").Run()
 			Expect(err).To(BeNil(), "fail to edit chaos experiment yaml")
 			err = exec.Command("kubectl", "apply", "-f", "pod-network-corruption.yaml", "-n", chaosTypes.ChaosNamespace).Run()
 			Expect(err).To(BeNil(), "fail to create chaos experiment")
-			fmt.Println("Chaos Experiment Created Successfully")
+			fmt.Println("Chaos Experiment Created Successfully with image =", chaosTypes.ExperimentRepoName, "/", chaosTypes.ExperimentImage, ":", chaosTypes.ExperimentImageTag)
 
 			//Installing chaos engine for the experiment
 			//Fetching engine file

--- a/tests/pod-network-latency_test.go
+++ b/tests/pod-network-latency_test.go
@@ -27,7 +27,6 @@ var (
 	client         *kubernetes.Clientset
 	clientSet      *chaosClient.LitmuschaosV1alpha1Client
 	err            error
-	image_tag      = os.Getenv("IMAGE_TAG")
 	experimentName = "pod-network-latency"
 	engineName     = "engine2"
 )
@@ -99,11 +98,11 @@ var _ = Describe("BDD of pod-delete experiment", func() {
 			By("Creating Experiment")
 			err = exec.Command("wget", "-O", "pod-network-latency.yaml", "https://hub.litmuschaos.io/api/chaos?file=charts/generic/pod-network-latency/experiment.yaml").Run()
 			Expect(err).To(BeNil(), "fail get chaos experiment")
-			err = exec.Command("sed", "-i", `s/ansible-runner:latest/ansible-runner:`+image_tag+`/g`, "pod-network-latency.yaml").Run()
+			err = exec.Command("sed", "-i", `s/litmuschaos\/ansible-runner:latest/`+chaosTypes.ExperimentRepoName+`\/`+chaosTypes.ExperimentImage+`:`+chaosTypes.ExperimentImageTag+`/g`, "pod-network-latency.yaml").Run()
 			Expect(err).To(BeNil(), "fail to edit chaos experiment yaml")
 			err = exec.Command("kubectl", "apply", "-f", "pod-network-latency.yaml", "-n", chaosTypes.ChaosNamespace).Run()
 			Expect(err).To(BeNil(), "fail to create chaos experiment")
-			fmt.Println("Chaos Experiment Created Successfully")
+			fmt.Println("Chaos Experiment Created Successfully with image =", chaosTypes.ExperimentRepoName, "/", chaosTypes.ExperimentImage, ":", chaosTypes.ExperimentImageTag)
 
 			//Installing chaos engine for the experiment
 			//Fetching engine file

--- a/tests/pod-network-loss_test.go
+++ b/tests/pod-network-loss_test.go
@@ -27,7 +27,6 @@ var (
 	client         *kubernetes.Clientset
 	clientSet      *chaosClient.LitmuschaosV1alpha1Client
 	err            error
-	image_tag      = os.Getenv("IMAGE_TAG")
 	experimentName = "pod-network-loss"
 	engineName     = "engine3"
 )
@@ -99,11 +98,11 @@ var _ = Describe("BDD of pod-delete experiment", func() {
 			By("Creating Experiment")
 			err = exec.Command("wget", "-O", "pod-network-loss.yaml", "https://hub.litmuschaos.io/api/chaos?file=charts/generic/pod-network-loss/experiment.yaml").Run()
 			Expect(err).To(BeNil(), "fail get chaos experiment")
-			err = exec.Command("sed", "-i", `s/ansible-runner:latest/ansible-runner:`+image_tag+`/g`, "pod-network-loss.yaml").Run()
+			err = exec.Command("sed", "-i", `s/litmuschaos\/ansible-runner:latest/`+chaosTypes.ExperimentRepoName+`\/`+chaosTypes.ExperimentImage+`:`+chaosTypes.ExperimentImageTag+`/g`, "pod-network-loss.yaml").Run()
 			Expect(err).To(BeNil(), "fail to edit chaos experiment yaml")
 			err = exec.Command("kubectl", "apply", "-f", "pod-network-loss.yaml", "-n", chaosTypes.ChaosNamespace).Run()
 			Expect(err).To(BeNil(), "fail to create chaos experiment")
-			fmt.Println("Chaos Experiment Created Successfully")
+			fmt.Println("Chaos Experiment Created Successfully with image =", chaosTypes.ExperimentRepoName, "/", chaosTypes.ExperimentImage, ":", chaosTypes.ExperimentImageTag)
 
 			//Installing chaos engine for the experiment
 			//Fetching engine file

--- a/types/types.go
+++ b/types/types.go
@@ -1,27 +1,42 @@
 package tests
 
 import (
+	"os"
+
 	"github.com/litmuschaos/chaos-operator/pkg/apis/litmuschaos/v1alpha1"
 )
 
 var (
 
-	// Namespace where the chaos will be performed
+	// ChaosNamespace where the chaos will be performed
 	ChaosNamespace = "litmus"
-
-	// Namespace where the csp pods are deployed
+	// CspPodNs where the csp pods are deployed
 	CspPodNs = "openebs"
-
-	//Label of the CSP Pods
+	//CspPodLabels of the CSP Pods
 	CspPodLabels = "app=cstor-pool"
-
-	//Namespace where target pod is deployed
+	//TargetPodNs Namespace where target pod is deployed
 	TargetPodNs = "openebs"
-
-	//Label of the target pod
+	//TargetPodLabels Label of the target pod
 	TargetPodLabels = "openebs.io/target=cstor-target"
-
-	//Chaos Duration of the Experiment
+	//ExperimentRepoName of the image to be used in experiment
+	ExperimentRepoName = os.Getenv("EXPERIMENT_REPO_NAME")
+	//OperatorRepoName of the image to be used in operator
+	OperatorRepoName = os.Getenv("OPERATOR_REPO_NAME")
+	//RunnerRepoName of the image to be used in runner
+	RunnerRepoName = os.Getenv("RUNNER_REPO_NAME")
+	//RunnerImage name
+	RunnerImage = os.Getenv("RUNNER_IMAGE")
+	//OperatorImage name
+	OperatorImage = os.Getenv("OPERATOR_IMAGE")
+	//ExperimentImage name
+	ExperimentImage = os.Getenv("EXPERIMENT_IMAGE")
+	//ExperimentImageTag "latest or ci"
+	ExperimentImageTag = os.Getenv("EXPERIMENT_IMAGE_TAG")
+	//OperatorImageTag "latest or ci"
+	OperatorImageTag = os.Getenv("OPERATOR_IMAGE_TAG")
+	//RunnerImageTag "latest or ci"
+	RunnerImageTag = os.Getenv("RUNNER_IMAGE_TAG")
+	//ChaosDuration of the Experiment
 	ChaosDuration = ""
 )
 


### PR DESCRIPTION

- Using custom Images of different components of litmus for running pipelines
- Currently, we are only taking the image tag from the Gitlab ENV. This Issue is for getting the complete image of different components which are chaos operator, chaos runner , chaos experiment form the ENV or custom values.

- For taking custom image values Gitlab will have following ENVs:
1. REPO_NAME: litmuschaos (default)
2. OPERATOR_IMAGE: chaos-operator (default)
3. RUNNER_IMAGE: chaos-runner (default)
4. EXPERIMENT_IMAGE: ansible-runner (default)
5. IMAGE_TAG: ci (default)

Signed-off-by: Udit Gaurav <uditgaurav@gmail.com>