### PR TITLE
(fix): Modify node name field in chaos engine of node drain

### DIFF
--- a/tests/node-drain_test.go
+++ b/tests/node-drain_test.go
@@ -135,6 +135,10 @@ var _ = Describe("BDD of node-drain experiment", func() {
 			         s/applabel: 'app=nginx'/applabel: 'run=nginx'/g`,
 				experimentName+"-ce.yaml").Run()
 
+			//Modify NODE NAME
+			err = exec.Command("sed", "-i", `/name: APP_NODE/{n;s/.*/              value: `+nodeName+"/}", experimentName+"-ce.yaml").Run()
+			Expect(err).To(BeNil(), "Fail to Modify Node name field of chaos engine")
+
 			//Creating ChaosEngine
 			By("Creating ChaosEngine")
 			err = exec.Command("kubectl", "apply", "-f", experimentName+"-ce.yaml", "-n", chaosTypes.ChaosNamespace).Run()


### PR DESCRIPTION
- Modify node name field in chaos engine of node drain
Signed-off-by: Udit Gaurav <uditgaurav@gmail.com>