### PR TITLE
chore(cluster): Separating target cluster for generic and openebs pipelines and some fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ build-litmus:
 	@echo "------------"
 	@echo "Build Litmus"
 	@echo "------------"
-	@sshpass -p ${pass} ssh -o StrictHostKeyChecking=no ${user}@${ip} -p ${port} -tt \
+	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
 	 "export CI_JOB_ID=${CI_JOB_ID} && export GITHUB_TOKEN=${GITHUB_TOKEN} && export EXPERIMENT_REPO_NAME=${EXPERIMENT_REPO_NAME} && \
 	 export OPERATOR_REPO_NAME=${OPERATOR_REPO_NAME} && export RUNNER_REPO_NAME=${RUNNER_REPO_NAME} && export RUNNER_IMAGE=${RUNNER_IMAGE} && \
 	 export OPERATOR_IMAGE=${OPERATOR_IMAGE} && export EXPERIMENT_IMAGE=${EXPERIMENT_IMAGE} && export EXPERIMENT_IMAGE_TAG=${EXPERIMENT_IMAGE_TAG} && \
@@ -21,7 +21,7 @@ app-deploy:
 	@echo "---------------------"
 	@echo "Deploying Application"
 	@echo "---------------------"
-	@sshpass -p ${pass} ssh -o StrictHostKeyChecking=no ${user}@${ip} -p ${port} -tt \
+	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
 	 "go test $(TESTPATH)/app-deploy_test.go -v -count=1"
 
 .PHONY: liveness
@@ -30,7 +30,7 @@ liveness:
 	@echo "---------------------"
 	@echo "Deploying Application"
 	@echo "---------------------"
-	@sshpass -p ${pass} ssh -o StrictHostKeyChecking=no ${user}@${ip} -p ${port} -tt \
+	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
      "go test $(TESTPATH)/app-liveness_test.go -v -count=1"
 
 .PHONY: auxiliary-app
@@ -39,7 +39,7 @@ auxiliary-app:
 	@echo "-----------------------"
 	@echo "Deploying Auxiliary App"
 	@echo "-----------------------"
-	@sshpass -p ${pass} ssh -o StrictHostKeyChecking=no ${user}@${ip} -p ${port} -tt \
+	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
 	 "go test $(TESTPATH)/auxiliary-app_test.go -v -count=1"
 
 .PHONY: pod-delete
@@ -48,7 +48,7 @@ pod-delete:
 	@echo "-------------------------------"
 	@echo "Running pod-delete experiment"
 	@echo "--------------------------------"
-	@sshpass -p ${pass} ssh -o StrictHostKeyChecking=no ${user}@${ip} -p ${port} -tt \
+	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
 	"export CI_JOB_ID=${CI_JOB_ID} && export GITHUB_TOKEN=${GITHUB_TOKEN} && export EXPERIMENT_REPO_NAME=${EXPERIMENT_REPO_NAME} && \
 	 export EXPERIMENT_IMAGE=${EXPERIMENT_IMAGE} && export EXPERIMENT_IMAGE_TAG=${EXPERIMENT_IMAGE_TAG} &&  \
 	 go test $(TESTPATH)/pod-delete_test.go -v -count=1"
@@ -59,7 +59,7 @@ container-kill:
 	@echo "-------------------------------"
 	@echo "Running container-kill experiment"
 	@echo "--------------------------------"
-	@sshpass -p ${pass} ssh -o StrictHostKeyChecking=no ${user}@${ip} -p ${port} -tt \
+	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
 	"export CI_JOB_ID=${CI_JOB_ID} && export GITHUB_TOKEN=${GITHUB_TOKEN} && export EXPERIMENT_REPO_NAME=${EXPERIMENT_REPO_NAME} && \
 	 export EXPERIMENT_IMAGE=${EXPERIMENT_IMAGE} && export EXPERIMENT_IMAGE_TAG=${EXPERIMENT_IMAGE_TAG} &&  \
 	 go test $(TESTPATH)/container-kill_test.go -v -count=1"
@@ -70,7 +70,7 @@ pod-network-latency:
 	@echo "--------------------------------------"
 	@echo "Running pod-network-latency experiment"
 	@echo "--------------------------------------"
-	@sshpass -p ${pass} ssh -o StrictHostKeyChecking=no ${user}@${ip} -p ${port} -tt \
+	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
 	"export CI_JOB_ID=${CI_JOB_ID} && export GITHUB_TOKEN=${GITHUB_TOKEN} && export EXPERIMENT_REPO_NAME=${EXPERIMENT_REPO_NAME} && \
 	 export EXPERIMENT_IMAGE=${EXPERIMENT_IMAGE} && export EXPERIMENT_IMAGE_TAG=${EXPERIMENT_IMAGE_TAG} &&  \
 	 go test $(TESTPATH)/pod-network-latency_test.go -v -count=1"
@@ -81,7 +81,7 @@ pod-network-loss:
 	@echo "-----------------------------------"
 	@echo "Running pod-network-loss experiment"
 	@echo "-----------------------------------"
-	@sshpass -p ${pass} ssh -o StrictHostKeyChecking=no ${user}@${ip} -p ${port} -tt \
+	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
 	"export CI_JOB_ID=${CI_JOB_ID} && export GITHUB_TOKEN=${GITHUB_TOKEN} && export EXPERIMENT_REPO_NAME=${EXPERIMENT_REPO_NAME} && \
 	 export EXPERIMENT_IMAGE=${EXPERIMENT_IMAGE} && export EXPERIMENT_IMAGE_TAG=${EXPERIMENT_IMAGE_TAG} &&  \
 	 go test $(TESTPATH)/pod-network-loss_test.go -v -count=1"
@@ -93,7 +93,7 @@ pod-network-corruption:
 	@echo "-------------------------------"
 	@echo "Running pod-network-corruption experiment"
 	@echo "--------------------------------"
-	@sshpass -p ${pass} ssh -o StrictHostKeyChecking=no ${user}@${ip} -p ${port} -tt \
+	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
 	"export CI_JOB_ID=${CI_JOB_ID} && export GITHUB_TOKEN=${GITHUB_TOKEN} && export EXPERIMENT_REPO_NAME=${EXPERIMENT_REPO_NAME} && \
 	 export EXPERIMENT_IMAGE=${EXPERIMENT_IMAGE} && export EXPERIMENT_IMAGE_TAG=${EXPERIMENT_IMAGE_TAG} &&  \
 	 go test $(TESTPATH)/pod-network-corruption_test.go -v -count=1"
@@ -104,7 +104,7 @@ pod-cpu-hog:
 	@echo "-------------------------------"
 	@echo "Running pod-cpu-hog experiment"
 	@echo "--------------------------------"
-	@sshpass -p ${pass} ssh -o StrictHostKeyChecking=no ${user}@${ip} -p ${port} -tt \
+	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
 	"export CI_JOB_ID=${CI_JOB_ID} && export GITHUB_TOKEN=${GITHUB_TOKEN} && export EXPERIMENT_REPO_NAME=${EXPERIMENT_REPO_NAME} && \
 	 export EXPERIMENT_IMAGE=${EXPERIMENT_IMAGE} && export EXPERIMENT_IMAGE_TAG=${EXPERIMENT_IMAGE_TAG} &&  \
 	 go test $(TESTPATH)/pod-cpu-hog_test.go -v -count=1"
@@ -115,7 +115,7 @@ node-cpu-hog:
 	@echo "-------------------------------"
 	@echo "Running node-cpu-hog experiment"
 	@echo "--------------------------------"
-	@sshpass -p ${pass} ssh -o StrictHostKeyChecking=no ${user}@${ip} -p ${port} -tt \
+	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
 	"export CI_JOB_ID=${CI_JOB_ID} && export GITHUB_TOKEN=${GITHUB_TOKEN} && export EXPERIMENT_REPO_NAME=${EXPERIMENT_REPO_NAME} && \
 	 export EXPERIMENT_IMAGE=${EXPERIMENT_IMAGE} && export EXPERIMENT_IMAGE_TAG=${EXPERIMENT_IMAGE_TAG} &&  \
 	 go test $(TESTPATH)/node-cpu-hog_test.go -v -count=1"
@@ -126,7 +126,7 @@ node-drain:
 	@echo "---------------------------------"
 	@echo "Running node-drain experiment"
 	@echo "---------------------------------"
-	@sshpass -p ${pass} ssh -o StrictHostKeyChecking=no ${user}@${ip} -p ${port} -tt \
+	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
 	"export CI_JOB_ID=${CI_JOB_ID} && export GITHUB_TOKEN=${GITHUB_TOKEN} && export EXPERIMENT_REPO_NAME=${EXPERIMENT_REPO_NAME} && \
 	 export EXPERIMENT_IMAGE=${EXPERIMENT_IMAGE} && export EXPERIMENT_IMAGE_TAG=${EXPERIMENT_IMAGE_TAG} &&  \
 	 go test $(TESTPATH)/node-drain_test.go -v -count=1"
@@ -137,7 +137,7 @@ disk-fill:
 	@echo "--------------------------------"
 	@echo "Running disk-fill experiment"
 	@echo "--------------------------------"
-	@sshpass -p ${pass} ssh -o StrictHostKeyChecking=no ${user}@${ip} -p ${port} -tt \
+	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
 	"export CI_JOB_ID=${CI_JOB_ID} && export GITHUB_TOKEN=${GITHUB_TOKEN} && export EXPERIMENT_REPO_NAME=${EXPERIMENT_REPO_NAME} && \
 	 export EXPERIMENT_IMAGE=${EXPERIMENT_IMAGE} && export EXPERIMENT_IMAGE_TAG=${EXPERIMENT_IMAGE_TAG} &&  \
 	 go test $(TESTPATH)/disk-fill_test.go -v -count=1"
@@ -148,7 +148,7 @@ node-memory-hog:
 	@echo "----------------------------------"
 	@echo "Running node-memory-hog experiment"
 	@echo "----------------------------------"
-	@sshpass -p ${pass} ssh -o StrictHostKeyChecking=no ${user}@${ip} -p ${port} -tt \
+	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
 	"export CI_JOB_ID=${CI_JOB_ID} && export GITHUB_TOKEN=${GITHUB_TOKEN} && export EXPERIMENT_REPO_NAME=${EXPERIMENT_REPO_NAME} && \
 	 export EXPERIMENT_IMAGE=${EXPERIMENT_IMAGE} && export EXPERIMENT_IMAGE_TAG=${EXPERIMENT_IMAGE_TAG} &&  \
 	 go test $(TESTPATH)/node-memory-hog_test.go -v -count=1"
@@ -159,7 +159,7 @@ pod-memory-hog:
 	@echo "---------------------------------"
 	@echo "Running pod-memory-hog experiment"
 	@echo "---------------------------------"
-	@sshpass -p ${pass} ssh -o StrictHostKeyChecking=no ${user}@${ip} -p ${port} -tt \
+	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
 	"export CI_JOB_ID=${CI_JOB_ID} && export GITHUB_TOKEN=${GITHUB_TOKEN} && export EXPERIMENT_REPO_NAME=${EXPERIMENT_REPO_NAME} && \
 	 export EXPERIMENT_IMAGE=${EXPERIMENT_IMAGE} && export EXPERIMENT_IMAGE_TAG=${EXPERIMENT_IMAGE_TAG} &&  \
 	 go test $(TESTPATH)/pod-memory-hog_test.go -v -count=1"
@@ -170,7 +170,7 @@ pod-memory-hog:
 	@echo "--------------------------------------------"
 	@echo "Running  Operator Reconcile Resiliency Check"
 	@echo "--------------------------------------------"
-	@sshpass -p ${pass} ssh -o StrictHostKeyChecking=no ${user}@${ip} -p ${port} -tt \
+	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
 	"export CI_JOB_ID=${CI_JOB_ID} && export GITHUB_TOKEN=${GITHUB_TOKEN} && export EXPERIMENT_REPO_NAME=${EXPERIMENT_REPO_NAME} && \
 	 export EXPERIMENT_IMAGE=${EXPERIMENT_IMAGE} && export EXPERIMENT_IMAGE_TAG=${EXPERIMENT_IMAGE_TAG} &&  \
 	 go test $(TESTPATH)/reconcile-resiliency_test.go -v -count=1"
@@ -181,7 +181,7 @@ admin-mode-check:
 	@echo "------------------------"
 	@echo "Running Admin Mode Check"
 	@echo "------------------------"
-	@sshpass -p ${pass} ssh -o StrictHostKeyChecking=no ${user}@${ip} -p ${port} -tt \
+	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
 	"export CI_JOB_ID=${CI_JOB_ID} && export GITHUB_TOKEN=${GITHUB_TOKEN} && export EXPERIMENT_REPO_NAME=${EXPERIMENT_REPO_NAME} && \
 	 export EXPERIMENT_IMAGE=${EXPERIMENT_IMAGE} && export EXPERIMENT_IMAGE_TAG=${EXPERIMENT_IMAGE_TAG} &&  \
 	 go test $(TESTPATH)/admin-mode_test.go -v -count=1"	
@@ -192,6 +192,6 @@ app-cleanup:
 	@echo "--------------------"
 	@echo "Deleting litmus"
 	@echo "--------------------"
-	@sshpass -p ${pass} ssh -o StrictHostKeyChecking=no ${user}@${ip} -p ${port} -tt \
+	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
 	 "go test $(TESTPATH)/litmus-cleanup_test.go -v -count=1"
 	 

--- a/build/gitlab/stages/3-cluster-connect/cluster-connect
+++ b/build/gitlab/stages/3-cluster-connect/cluster-connect
@@ -8,9 +8,9 @@ path=$(pwd)
 printf "***Conneting to the Cluster*****\n\n"
 
 ##Checking the Cluster Connection 
-sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'ls'
+sshpass -p $litmus_pass ssh -o StrictHostKeyChecking=no $litmus_user@$litmus_ip -p $port 'ls'
 ##Setup GOPATH
-sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'mkdir -p go/src/github.com/litmuschaos'
+sshpass -p $litmus_pass ssh -o StrictHostKeyChecking=no $litmus_user@$litmus_ip -p $port 'mkdir -p go/src/github.com/litmuschaos'
 echo "Go path created"
 
 #Checking Cluster's Health 
@@ -18,18 +18,18 @@ echo "*****************************Checking the Cluster's Health****************
 echo "************    Checking for the number of nodes in ready state      **************"
 
 ##Number of nodes in the cluster
-ready_nodes=$(sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port kubectl get nodes --no-headers | grep -v NotReady | wc -l)
+ready_nodes=$(sshpass -p $litmus_pass ssh -o StrictHostKeyChecking=no $litmus_user@$litmus_ip -p $port kubectl get nodes --no-headers | grep -v NotReady | wc -l)
 echo "Number of nodes in ready state is $ready_nodes"
 if [ "$ready_nodes" -eq 4 ]; then
     printf "Cluster is up and running with $ready_nodes nodes\n"
    
 echo "**************************Checking if Cluster is Engaged or not****************"
-litmus_exist=$(sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'ls /home/udit/go/src/github.com/litmuschaos | grep litmus-e2e')
+litmus_exist=$(sshpass -p $litmus_pass ssh -o StrictHostKeyChecking=no $litmus_user@$litmus_ip -p $port 'ls /home/udit/go/src/github.com/litmuschaos | grep litmus-e2e')
 if [ -n "$litmus_exist" ]; then
     echo "Litmus already exist please cleanup the last session"
     exit 1;
 else
-sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'cd /home/udit/go/src/github.com/litmuschaos && git clone https://github.com/litmuschaos/litmus-e2e.git -b generic'
+sshpass -p $litmus_pass ssh -o StrictHostKeyChecking=no $litmus_user@$litmus_ip -p $port 'cd /home/udit/go/src/github.com/litmuschaos && git clone https://github.com/litmuschaos/litmus-e2e.git -b generic'
 fi
 else
 	echo "The cluster is not in Ready state"
@@ -37,6 +37,6 @@ else
 fi
 
 echo "Getting the Nodes of the Cluster"
-sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'kubectl get nodes'
+sshpass -p $litmus_pass ssh -o StrictHostKeyChecking=no $litmus_user@$litmus_ip -p $port 'kubectl get nodes'
 echo "Getting the pods from all namespaces"
-sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'kubectl get pods --all-namespaces'
+sshpass -p $litmus_pass ssh -o StrictHostKeyChecking=no $litmus_user@$litmus_ip -p $port 'kubectl get pods --all-namespaces'

--- a/build/gitlab/stages/4-cluster-disconnect/cluster-disconnect
+++ b/build/gitlab/stages/4-cluster-disconnect/cluster-disconnect
@@ -7,11 +7,11 @@ path=$(pwd)
 
 #Removing the litmus cloned directory
 echo "Removing the litmus cloned directory"
-sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'rm -rf /home/udit/go/src/github.com/litmuschaos/litmus-e2e'
+sshpass -p $litmus_pass ssh -o StrictHostKeyChecking=no $litmus_user@$litmus_ip -p $port 'rm -rf /home/udit/go/src/github.com/litmuschaos/litmus-e2e'
 
 printf "***Checking if the cluster is ready to disconnect*****\n\n"
 ##Checking if the cluster is ready to disconnect
-litmus_ns="sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'kubectl get ns litmus -o jsonpath='{.metadata.name}''"
+litmus_ns="sshpass -p $litmus_pass ssh -o StrictHostKeyChecking=no $litmus_user@$litmus_ip -p $port 'kubectl get ns litmus -o jsonpath='{.metadata.name}''"
 if [  "$litmus_ns" = "litmus-e2e" ]; then
   echo "Please Delete Litmus Namespace"
   exit 1;
@@ -22,7 +22,7 @@ echo "*****************************Checking the Cluster's Health****************
 echo "************    Checking for the number of nodes in ready state      **************"
 
 ##Number of nodes in the cluster
-ready_nodes=$(sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port kubectl get nodes --no-headers | grep -v NotReady | wc -l)
+ready_nodes=$(sshpass -p $litmus_pass ssh -o StrictHostKeyChecking=no $litmus_user@$litmus_ip -p $port kubectl get nodes --no-headers | grep -v NotReady | wc -l)
 echo "Number of nodes in ready state is $ready_nodes"
 if [ "$ready_nodes" -eq 4 ]; then
     printf "Cluster is up and running with $ready_nodes nodes\n"

--- a/tests/pod-network-corruption_test.go
+++ b/tests/pod-network-corruption_test.go
@@ -113,7 +113,7 @@ var _ = Describe("BDD of pod-network-corruption experiment", func() {
 
 			err = exec.Command("sed", "-i",
 				`s/namespace: default/namespace: litmus/g;
-			         s/name:  nginx-network-chaos/name: `+engineName+`/g;
+			         s/name: nginx-network-chaos/name: `+engineName+`/g;
 					 s/appns: 'default'/appns: 'litmus'/g;
 					 s/jobCleanUpPolicy: 'delete'/jobCleanUpPolicy: 'retain'/g;
 					 s/annotationCheck: 'true'/annotationCheck: 'false'/g;

--- a/tests/pod-network-latency_test.go
+++ b/tests/pod-network-latency_test.go
@@ -115,7 +115,7 @@ var _ = Describe("BDD of pod-network-latency experiment", func() {
 
 			err = exec.Command("sed", "-i",
 				`s/namespace: default/namespace: litmus/g;
-			         s/name:  nginx-network-chaos/name: `+engineName+`/g;
+			         s/name: nginx-network-chaos/name: `+engineName+`/g;
 					 s/appns: 'default'/appns: 'litmus'/g;
 					 s/jobCleanUpPolicy: 'delete'/jobCleanUpPolicy: 'retain'/g;
 					 s/annotationCheck: 'true'/annotationCheck: 'false'/g;


### PR DESCRIPTION
- This PR contains:
   - A different target cluster for generic and openebs experiments which will help in parallel execution of both the pipelines. For this, a different `IP` , `user` , `password` is required which are `litmus_ip` , `litmus_user` & `litmus_pass` for generic pipelines and these are placed in GitLab ENVs.

   - Updated the engine changes from chaos-charts to edit the engine name.
 
Signed-off-by: Udit Gaurav <uditgaurav@gmail.com>