### PR TITLE
chore(BDD): Add pod network duplication also go experiment Image in e2e pipeline 

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -187,7 +187,22 @@ pod-memory-hog:
   artifacts:
     when: always
     paths:
-      - .kube/      
+      - .kube/
+
+pod-network-duplication:
+
+  when: always
+  image: litmuschaos/litmus-e2e:latest
+  stage: generic-experiment
+  tags:
+    - litmus-build
+  script:
+    - make pod-network-duplication
+
+  artifacts:
+    when: always
+    paths:
+      - .kube/ 
 
 node-cpu-hog:
 

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ pod-delete:
 	@echo "--------------------------------"
 	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
 	"export CGO_ENABLED=0 && export CI_JOB_ID=${CI_JOB_ID} && export GITHUB_TOKEN=${GITHUB_TOKEN} && export EXPERIMENT_REPO_NAME=${EXPERIMENT_REPO_NAME} && \
-	 export EXPERIMENT_IMAGE=${EXPERIMENT_IMAGE} && export EXPERIMENT_IMAGE_TAG=${EXPERIMENT_IMAGE_TAG} &&  \
+	 export GO_EXPERIMENT_IMAGE=${GO_EXPERIMENT_IMAGE} && export EXPERIMENT_IMAGE_TAG=${EXPERIMENT_IMAGE_TAG} &&  \
 	 go test $(TESTPATH)/tests/pod-delete_test.go -v -count=1"
 
 .PHONY: container-kill
@@ -118,7 +118,7 @@ pod-cpu-hog:
 	@echo "--------------------------------"
 	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
 	"export CGO_ENABLED=0 && export CI_JOB_ID=${CI_JOB_ID} && export GITHUB_TOKEN=${GITHUB_TOKEN} && export EXPERIMENT_REPO_NAME=${EXPERIMENT_REPO_NAME} && \
-	 export EXPERIMENT_IMAGE=${EXPERIMENT_IMAGE} && export EXPERIMENT_IMAGE_TAG=${EXPERIMENT_IMAGE_TAG} &&  \
+	 export GO_EXPERIMENT_IMAGE=${GO_EXPERIMENT_IMAGE} && export EXPERIMENT_IMAGE_TAG=${EXPERIMENT_IMAGE_TAG} &&  \
 	 go test $(TESTPATH)/tests/pod-cpu-hog_test.go -v -count=1"
 
 .PHONY: node-cpu-hog
@@ -173,19 +173,29 @@ pod-memory-hog:
 	@echo "---------------------------------"
 	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
 	"export CGO_ENABLED=0 && export CI_JOB_ID=${CI_JOB_ID} && export GITHUB_TOKEN=${GITHUB_TOKEN} && export EXPERIMENT_REPO_NAME=${EXPERIMENT_REPO_NAME} && \
-	 export EXPERIMENT_IMAGE=${EXPERIMENT_IMAGE} && export EXPERIMENT_IMAGE_TAG=${EXPERIMENT_IMAGE_TAG} &&  \
+	 export GO_EXPERIMENT_IMAGE=${GO_EXPERIMENT_IMAGE} && export EXPERIMENT_IMAGE_TAG=${EXPERIMENT_IMAGE_TAG} &&  \
 	 go test $(TESTPATH)/tests/pod-memory-hog_test.go -v -count=1"
 
 .PHONY: kubelet-service-kill
 kubelet-service-kill:
 
-	@echo "---------------------------------"
+	@echo "---------------------------------------"
 	@echo "Running kubelet-service-kill experiment"
-	@echo "---------------------------------"
+	@echo "---------------------------------------"
 	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
 	"export CGO_ENABLED=0 && export CI_JOB_ID=${CI_JOB_ID} && export GITHUB_TOKEN=${GITHUB_TOKEN} && export EXPERIMENT_REPO_NAME=${EXPERIMENT_REPO_NAME} && \
 	 export EXPERIMENT_IMAGE=${EXPERIMENT_IMAGE} && export EXPERIMENT_IMAGE_TAG=${EXPERIMENT_IMAGE_TAG} &&  \
-	 go test $(TESTPATH)/tests/pod-memory-hog_test.go -v -count=1"	 
+	 go test $(TESTPATH)/tests/pod-memory-hog_test.go -v -count=1"
+
+.PHONY: pod-network-duplication
+pod-network-duplication:
+
+	@echo "------------------------------------------"
+	@echo "Running pod-network-duplication experiment"
+	@echo "------------------------------------------"
+	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
+	"export CGO_ENABLED=0 && export CI_JOB_ID=${CI_JOB_ID} && export GITHUB_TOKEN=${GITHUB_TOKEN} && \ export GOEXPERIMENT_IMAGE=${GOEXPERIMENT_IMAGE} &&  \
+	 go test $(TESTPATH)/tests/pod-network-duplication_test.go -v -count=1"	  
 
 .PHONY:  operator-reconcile-resiliency-check
  operator-reconcile-resiliency-check:

--- a/tests/container-kill_test.go
+++ b/tests/container-kill_test.go
@@ -63,14 +63,14 @@ var _ = BeforeSuite(func() {
 		fmt.Println(err)
 	}
 
-	//Getting the Application Status
+	//Getting the Chaos Operator Status
 	app, _ := client.AppsV1().Deployments(chaosTypes.ChaosNamespace).Get("chaos-operator-ce", metav1.GetOptions{})
 	count := 0
 	for app.Status.UnavailableReplicas != 0 {
-		if count < 50 {
-			fmt.Printf("Application is Creating, Currently Unavaliable Count is: %v \n", app.Status.UnavailableReplicas)
+		if count < 10 {
+			fmt.Printf("Operator is not in ready state, Currently Unavaliable Count is: %v \n", app.Status.UnavailableReplicas)
 			app, _ = client.AppsV1().Deployments(chaosTypes.ChaosNamespace).Get("chaos-operator-ce", metav1.GetOptions{})
-			time.Sleep(10 * time.Second)
+			time.Sleep(5 * time.Second)
 			count++
 		} else {
 			Fail("Application fails to get in ready state")

--- a/tests/disk-fill_test.go
+++ b/tests/disk-fill_test.go
@@ -67,10 +67,10 @@ var _ = BeforeSuite(func() {
 	app, _ := client.AppsV1().Deployments(chaosTypes.ChaosNamespace).Get("chaos-operator-ce", metav1.GetOptions{})
 	count := 0
 	for app.Status.UnavailableReplicas != 0 {
-		if count < 50 {
-			fmt.Printf("Application is Creating, Currently Unavaliable Count is: %v \n", app.Status.UnavailableReplicas)
+		if count < 10 {
+			fmt.Printf("Operator is not in ready state, Currently Unavaliable Count is: %v \n", app.Status.UnavailableReplicas)
 			app, _ = client.AppsV1().Deployments(chaosTypes.ChaosNamespace).Get("chaos-operator-ce", metav1.GetOptions{})
-			time.Sleep(10 * time.Second)
+			time.Sleep(5 * time.Second)
 			count++
 		} else {
 			Fail("Application fails to get in ready state")

--- a/tests/kubelet-service-kill_test.go
+++ b/tests/kubelet-service-kill_test.go
@@ -67,10 +67,10 @@ var _ = BeforeSuite(func() {
 	app, _ := client.AppsV1().Deployments(chaosTypes.ChaosNamespace).Get("chaos-operator-ce", metav1.GetOptions{})
 	count := 0
 	for app.Status.UnavailableReplicas != 0 {
-		if count < 50 {
-			fmt.Printf("Application is Creating, Currently Unavaliable Count is: %v \n", app.Status.UnavailableReplicas)
+		if count < 10 {
+			fmt.Printf("Operator is not in ready state, Currently Unavaliable Count is: %v \n", app.Status.UnavailableReplicas)
 			app, _ = client.AppsV1().Deployments(chaosTypes.ChaosNamespace).Get("chaos-operator-ce", metav1.GetOptions{})
-			time.Sleep(10 * time.Second)
+			time.Sleep(5 * time.Second)
 			count++
 		} else {
 			Fail("Application fails to get in ready state")

--- a/tests/node-cpu-hog_test.go
+++ b/tests/node-cpu-hog_test.go
@@ -67,10 +67,10 @@ var _ = BeforeSuite(func() {
 	app, _ := client.AppsV1().Deployments(chaosTypes.ChaosNamespace).Get("chaos-operator-ce", metav1.GetOptions{})
 	count := 0
 	for app.Status.UnavailableReplicas != 0 {
-		if count < 50 {
-			fmt.Printf("Application is Creating, Currently Unavaliable Count is: %v \n", app.Status.UnavailableReplicas)
+		if count < 10 {
+			fmt.Printf("Operator is not in ready state, Currently Unavaliable Count is: %v \n", app.Status.UnavailableReplicas)
 			app, _ = client.AppsV1().Deployments(chaosTypes.ChaosNamespace).Get("chaos-operator-ce", metav1.GetOptions{})
-			time.Sleep(10 * time.Second)
+			time.Sleep(5 * time.Second)
 			count++
 		} else {
 			Fail("Application fails to get in ready state")

--- a/tests/node-memory-hog_test.go
+++ b/tests/node-memory-hog_test.go
@@ -67,10 +67,10 @@ var _ = BeforeSuite(func() {
 	app, _ := client.AppsV1().Deployments(chaosTypes.ChaosNamespace).Get("chaos-operator-ce", metav1.GetOptions{})
 	count := 0
 	for app.Status.UnavailableReplicas != 0 {
-		if count < 50 {
-			fmt.Printf("Application is Creating, Currently Unavaliable Count is: %v \n", app.Status.UnavailableReplicas)
+		if count < 10 {
+			fmt.Printf("Operator is not in ready state, Currently Unavaliable Count is: %v \n", app.Status.UnavailableReplicas)
 			app, _ = client.AppsV1().Deployments(chaosTypes.ChaosNamespace).Get("chaos-operator-ce", metav1.GetOptions{})
-			time.Sleep(10 * time.Second)
+			time.Sleep(5 * time.Second)
 			count++
 		} else {
 			Fail("Application fails to get in ready state")

--- a/tests/pod-cpu-hog_test.go
+++ b/tests/pod-cpu-hog_test.go
@@ -67,10 +67,10 @@ var _ = BeforeSuite(func() {
 	app, _ := client.AppsV1().Deployments(chaosTypes.ChaosNamespace).Get("chaos-operator-ce", metav1.GetOptions{})
 	count := 0
 	for app.Status.UnavailableReplicas != 0 {
-		if count < 50 {
-			fmt.Printf("Application is Creating, Currently Unavaliable Count is: %v \n", app.Status.UnavailableReplicas)
+		if count < 10 {
+			fmt.Printf("Operator is not in ready state, Currently Unavaliable Count is: %v \n", app.Status.UnavailableReplicas)
 			app, _ = client.AppsV1().Deployments(chaosTypes.ChaosNamespace).Get("chaos-operator-ce", metav1.GetOptions{})
-			time.Sleep(10 * time.Second)
+			time.Sleep(5 * time.Second)
 			count++
 		} else {
 			Fail("Application fails to get in ready state")
@@ -99,11 +99,11 @@ var _ = Describe("BDD of pod-cpu-hog experiment", func() {
 			By("Creating Experiment")
 			err = exec.Command("wget", "-O", "pod-cpu-hog.yaml", "https://hub.litmuschaos.io/api/chaos/master?file=charts/generic/pod-cpu-hog/experiment.yaml").Run()
 			Expect(err).To(BeNil(), "fail get chaos experiment")
-			err = exec.Command("sed", "-i", `s/litmuschaos\/ansible-runner:latest/`+chaosTypes.ExperimentRepoName+`\/`+chaosTypes.ExperimentImage+`:`+chaosTypes.ExperimentImageTag+`/g`, "pod-cpu-hog.yaml").Run()
+			err = exec.Command("sed", "-i", `s/litmuschaos\/go-runner:latest/`+chaosTypes.ExperimentRepoName+`\/`+chaosTypes.GOExperimentImage+`:`+chaosTypes.ExperimentImageTag+`/g`, "pod-cpu-hog.yaml").Run()
 			Expect(err).To(BeNil(), "fail to edit chaos experiment yaml")
 			err = exec.Command("kubectl", "apply", "-f", "pod-cpu-hog.yaml", "-n", chaosTypes.ChaosNamespace).Run()
 			Expect(err).To(BeNil(), "fail to create chaos experiment")
-			fmt.Println("Chaos Experiment Created Successfully with image =", chaosTypes.ExperimentRepoName, "/", chaosTypes.ExperimentImage, ":", chaosTypes.ExperimentImageTag)
+			fmt.Println("Chaos Experiment Created Successfully with image =", chaosTypes.ExperimentRepoName, "/", chaosTypes.GOExperimentImage, ":", chaosTypes.ExperimentImageTag)
 
 			//Installing chaos engine for the experiment
 			//Fetching engine file

--- a/tests/pod-delete_test.go
+++ b/tests/pod-delete_test.go
@@ -67,10 +67,10 @@ var _ = BeforeSuite(func() {
 	app, _ := client.AppsV1().Deployments(chaosTypes.ChaosNamespace).Get("chaos-operator-ce", metav1.GetOptions{})
 	count := 0
 	for app.Status.UnavailableReplicas != 0 {
-		if count < 50 {
-			fmt.Printf("Application is Creating, Currently Unavaliable Count is: %v \n", app.Status.UnavailableReplicas)
+		if count < 10 {
+			fmt.Printf("Operator is not in ready state, Currently Unavaliable Count is: %v \n", app.Status.UnavailableReplicas)
 			app, _ = client.AppsV1().Deployments(chaosTypes.ChaosNamespace).Get("chaos-operator-ce", metav1.GetOptions{})
-			time.Sleep(10 * time.Second)
+			time.Sleep(5 * time.Second)
 			count++
 		} else {
 			Fail("Application fails to get in ready state")
@@ -99,11 +99,11 @@ var _ = Describe("BDD of pod-delete experiment", func() {
 			By("Creating Experiment")
 			err = exec.Command("wget", "-O", "pod-delete.yaml", "https://hub.litmuschaos.io/api/chaos/master?file=charts/generic/pod-delete/experiment.yaml").Run()
 			Expect(err).To(BeNil(), "fail get chaos experiment")
-			err = exec.Command("sed", "-i", `s/litmuschaos\/ansible-runner:latest/`+chaosTypes.ExperimentRepoName+`\/`+chaosTypes.ExperimentImage+`:`+chaosTypes.ExperimentImageTag+`/g`, "pod-delete.yaml").Run()
+			err = exec.Command("sed", "-i", `s/litmuschaos\/go-runner:latest/`+chaosTypes.ExperimentRepoName+`\/`+chaosTypes.GOExperimentImage+`:`+chaosTypes.ExperimentImageTag+`/g`, "pod-delete.yaml").Run()
 			Expect(err).To(BeNil(), "fail to edit chaos experiment yaml")
 			err = exec.Command("kubectl", "apply", "-f", "pod-delete.yaml", "-n", chaosTypes.ChaosNamespace).Run()
 			Expect(err).To(BeNil(), "fail to create chaos experiment")
-			fmt.Println("Chaos Experiment Created Successfully with image =", chaosTypes.ExperimentRepoName, "/", chaosTypes.ExperimentImage, ":", chaosTypes.ExperimentImageTag)
+			fmt.Println("Chaos Experiment Created Successfully with image =", chaosTypes.ExperimentRepoName, "/", chaosTypes.GOExperimentImage, ":", chaosTypes.ExperimentImageTag)
 
 			//Installing chaos engine for the experiment
 			//Fetching engine file

--- a/tests/pod-memory-hog_test.go
+++ b/tests/pod-memory-hog_test.go
@@ -67,10 +67,10 @@ var _ = BeforeSuite(func() {
 	app, _ := client.AppsV1().Deployments(chaosTypes.ChaosNamespace).Get("chaos-operator-ce", metav1.GetOptions{})
 	count := 0
 	for app.Status.UnavailableReplicas != 0 {
-		if count < 50 {
-			fmt.Printf("Application is Creating, Currently Unavaliable Count is: %v \n", app.Status.UnavailableReplicas)
+		if count < 10 {
+			fmt.Printf("Operator is not in ready state, Currently Unavaliable Count is: %v \n", app.Status.UnavailableReplicas)
 			app, _ = client.AppsV1().Deployments(chaosTypes.ChaosNamespace).Get("chaos-operator-ce", metav1.GetOptions{})
-			time.Sleep(10 * time.Second)
+			time.Sleep(5 * time.Second)
 			count++
 		} else {
 			Fail("Application fails to get in ready state")
@@ -99,11 +99,11 @@ var _ = Describe("BDD of pod-memory-hog experiment", func() {
 			By("Creating Experiment")
 			err = exec.Command("wget", "-O", "pod-memory-hog.yaml", "https://hub.litmuschaos.io/api/chaos/master?file=charts/generic/pod-memory-hog/experiment.yaml").Run()
 			Expect(err).To(BeNil(), "fail get chaos experiment")
-			err = exec.Command("sed", "-i", `s/litmuschaos\/ansible-runner:latest/`+chaosTypes.ExperimentRepoName+`\/`+chaosTypes.ExperimentImage+`:`+chaosTypes.ExperimentImageTag+`/g`, "pod-memory-hog.yaml").Run()
+			err = exec.Command("sed", "-i", `s/litmuschaos\/go-runner:latest/`+chaosTypes.ExperimentRepoName+`\/`+chaosTypes.GOExperimentImage+`:`+chaosTypes.ExperimentImageTag+`/g`, "pod-memory-hog.yaml").Run()
 			Expect(err).To(BeNil(), "fail to edit chaos experiment yaml")
 			err = exec.Command("kubectl", "apply", "-f", "pod-memory-hog.yaml", "-n", chaosTypes.ChaosNamespace).Run()
 			Expect(err).To(BeNil(), "fail to create chaos experiment")
-			fmt.Println("Chaos Experiment Created Successfully with image =", chaosTypes.ExperimentRepoName, "/", chaosTypes.ExperimentImage, ":", chaosTypes.ExperimentImageTag)
+			fmt.Println("Chaos Experiment Created Successfully with image =", chaosTypes.ExperimentRepoName, "/", chaosTypes.GOExperimentImage, ":", chaosTypes.ExperimentImageTag)
 
 			//Installing chaos engine for the experiment
 			//Fetching engine file

--- a/tests/pod-network-corruption_test.go
+++ b/tests/pod-network-corruption_test.go
@@ -67,10 +67,10 @@ var _ = BeforeSuite(func() {
 	app, _ := client.AppsV1().Deployments(chaosTypes.ChaosNamespace).Get("chaos-operator-ce", metav1.GetOptions{})
 	count := 0
 	for app.Status.UnavailableReplicas != 0 {
-		if count < 50 {
-			fmt.Printf("Application is Creating, Currently Unavaliable Count is: %v \n", app.Status.UnavailableReplicas)
+		if count < 10 {
+			fmt.Printf("Operator is not in ready state, Currently Unavaliable Count is: %v \n", app.Status.UnavailableReplicas)
 			app, _ = client.AppsV1().Deployments(chaosTypes.ChaosNamespace).Get("chaos-operator-ce", metav1.GetOptions{})
-			time.Sleep(10 * time.Second)
+			time.Sleep(5 * time.Second)
 			count++
 		} else {
 			Fail("Application fails to get in ready state")

--- a/tests/pod-network-latency_test.go
+++ b/tests/pod-network-latency_test.go
@@ -67,10 +67,10 @@ var _ = BeforeSuite(func() {
 	app, _ := client.AppsV1().Deployments(chaosTypes.ChaosNamespace).Get("chaos-operator-ce", metav1.GetOptions{})
 	count := 0
 	for app.Status.UnavailableReplicas != 0 {
-		if count < 50 {
-			fmt.Printf("Application is Creating, Currently Unavaliable Count is: %v \n", app.Status.UnavailableReplicas)
+		if count < 10 {
+			fmt.Printf("Operator is not in ready state, Currently Unavaliable Count is: %v \n", app.Status.UnavailableReplicas)
 			app, _ = client.AppsV1().Deployments(chaosTypes.ChaosNamespace).Get("chaos-operator-ce", metav1.GetOptions{})
-			time.Sleep(10 * time.Second)
+			time.Sleep(5 * time.Second)
 			count++
 		} else {
 			Fail("Application fails to get in ready state")

--- a/tests/pod-network-loss_test.go
+++ b/tests/pod-network-loss_test.go
@@ -67,10 +67,10 @@ var _ = BeforeSuite(func() {
 	app, _ := client.AppsV1().Deployments(chaosTypes.ChaosNamespace).Get("chaos-operator-ce", metav1.GetOptions{})
 	count := 0
 	for app.Status.UnavailableReplicas != 0 {
-		if count < 50 {
-			fmt.Printf("Application is Creating, Currently Unavaliable Count is: %v \n", app.Status.UnavailableReplicas)
+		if count < 10 {
+			fmt.Printf("Operator is not in ready state, Currently Unavaliable Count is: %v \n", app.Status.UnavailableReplicas)
 			app, _ = client.AppsV1().Deployments(chaosTypes.ChaosNamespace).Get("chaos-operator-ce", metav1.GetOptions{})
-			time.Sleep(10 * time.Second)
+			time.Sleep(5 * time.Second)
 			count++
 		} else {
 			Fail("Application fails to get in ready state")

--- a/types/types.go
+++ b/types/types.go
@@ -37,6 +37,8 @@ var (
 	OperatorImage = os.Getenv("OPERATOR_IMAGE")
 	//ExperimentImage name default: "ansible-runner"
 	ExperimentImage = os.Getenv("EXPERIMENT_IMAGE")
+	//GOExperimentImage name default: "go-runner"
+	GOExperimentImage = os.Getenv("GO_EXPERIMENT_IMAGE")
 	//ExperimentImageTag "latest or ci"
 	ExperimentImageTag = os.Getenv("EXPERIMENT_IMAGE_TAG")
 	//OperatorImageTag "latest or ci"


### PR DESCRIPTION
Signed-off-by: Udit Gaurav <udit.gaurav@mayadata.io>

- Add pod memory hog experiment in the litmus-e2e pipeline 
- Add Go-based experiment image in few experiments like in pod-memory hog, pod-cpu-hog, pod-delete. 

fixes:
- https://github.com/litmuschaos/litmus/issues/1652