### PR TITLE
feat(coverage): Add coverage percentage bar in readme and ci website for generic

### DIFF
--- a/metrics/e2e-metrics
+++ b/metrics/e2e-metrics
@@ -27,8 +27,9 @@ sleep 50
 # Fetching coverage percentage from custom resource
 e2e_coverage_cr=$(kubectl get pcover -n $COVERAGE_NAMESPACE --no-headers | awk '{print $1}')
 kubectl get pcover $e2e_coverage_cr -n $COVERAGE_NAMESPACE -oyaml
-kubectl get pcover -n $COVERAGE_NAMESPACE -o=jsonpath='{.items[0].result.coverage}{"\n"}'
-sleep 5
+coverage_percentage=$(kubectl get pcover -n $COVERAGE_NAMESPACE -o=jsonpath='{.items[0].result.coverage}')
+echo "${coverage_percentage::-1}" >> coverage
+sleep 2
 
 #clean up
 kubectl delete -f e2e-metrics/deploy/rbac.yaml

--- a/pkg/utils/update.go
+++ b/pkg/utils/update.go
@@ -43,7 +43,7 @@ func UpdateResultTable(clientSet *chaosClient.LitmuschaosV1alpha1Client, experim
 }
 
 //UpdatePipelineStatus will update the status of pipeline at the end of all jobs
-func UpdatePipelineStatus() error {
+func UpdatePipelineStatus(coverageData string) error {
 
 	var out bytes.Buffer
 	var stderr bytes.Buffer
@@ -51,7 +51,7 @@ func UpdatePipelineStatus() error {
 	klog.Info("The pipeline id is:", os.Getenv("CI_PIPELINE_ID"))
 	klog.Info("The release tag for running pipeline is:", chaosTypes.ExperimentImageTag)
 	// Recording job number for pipeline update
-	cmd := exec.Command("python3", "-u", "../utils/pipeline_status_update.py", "--pipeline_id", os.Getenv("CI_PIPELINE_ID"), "--tag", chaosTypes.ExperimentImageTag, "--time_stamp", (time.Now().Format(time.ANSIC))+"(IST)", "--token", os.Getenv("GITHUB_TOKEN"))
+	cmd := exec.Command("python3", "-u", "../utils/pipeline_status_update.py", "--pipeline_id", os.Getenv("CI_PIPELINE_ID"), "--tag", chaosTypes.ExperimentImageTag, "--time_stamp", (time.Now().Format(time.ANSIC))+"(IST)", "--coverage", coverageData, "--token", os.Getenv("GITHUB_TOKEN"))
 	cmd.Stdout = &out
 	cmd.Stderr = &stderr
 	err = cmd.Run()

--- a/tests/pipeline-update_test.go
+++ b/tests/pipeline-update_test.go
@@ -1,6 +1,10 @@
 package tests
 
 import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"strings"
 	"testing"
 
 	"github.com/litmuschaos/litmus-e2e/pkg/utils"
@@ -27,7 +31,13 @@ var _ = Describe("BDD of pipeline status update", func() {
 			//Updating the pipeline status table
 			By("Updating the pipeline status table")
 			var err error
-			err = utils.UpdatePipelineStatus()
+			coverageData, err := ioutil.ReadFile("../coverage")
+			if err != nil {
+				log.Panicf("failed reading coverageData from file: %s", err)
+			}
+			lines := strings.Split(string(coverageData), "\n")
+			fmt.Printf("\nFile Content: %s\n", string(lines[0]))
+			err = utils.UpdatePipelineStatus(string(lines[0]))
 			Expect(err).To(BeNil(), "Fail run the script for pipeline status updation")
 			klog.Info("Pipeline status updated successfully !!!")
 

--- a/utils/pipeline_status_update.py
+++ b/utils/pipeline_status_update.py
@@ -13,6 +13,9 @@ parser = argparse.ArgumentParser()
 parser.add_argument("--pipeline_id",
        help="gitlab pipeline id to create gitlab pipeline_url")
 
+parser.add_argument("--coverage",
+       help="getting the pipeline coverage")
+
 parser.add_argument("--tag",
        help="gitlab pipeline release tag")
 
@@ -24,6 +27,7 @@ parser.add_argument("--token",
 
 args = parser.parse_args()
 pipeline_id = args.pipeline_id
+coverage = args.coverage
 tag = args.tag
 time_stamp = args.time_stamp
 token = args.token
@@ -47,24 +51,24 @@ def fetch_file_content():
     file = repo.get_contents(file_path, "master")
     file_content=str(file.decoded_content, 'utf-8')
     content_list = file_content.split('\n')
+    totalCoverage= '[!['+coverage+'%](https://progress-bar.dev/'+coverage+')](https://bit.ly/2OLie8t)'
 
     # updating result's table if the table is already there
     if file_content.find('|')>0:
-        new_pipeline = '|     {}           |  {}           | {}  |'.format(pipeline_url,time_stamp,tag)
-        index = content_list.index('| Pipeline ID |   Execution Time        | Release Version |')
+        new_pipeline = '|     {}           |  {}           | {}  | {}  |'.format(pipeline_url,time_stamp,tag,totalCoverage)
+        index = content_list.index('| Pipeline ID |   Execution Time        | Release Version | Coverage (in %) |')
         content_list.insert(index+2,new_pipeline)
         updated_file_content = ('\n').join(content_list)
 
     # creating result's table for first pipeline result entry 
     else:
-        updated_file_content =  '| Pipeline ID |   Execution Time        | Release Version |\n'
-        updated_file_content = updated_file_content + ('|---------|---------------------------| --------------|\n')
-        updated_file_content = updated_file_content + ('|    {}   |  {}           |  {}     |\n'.format(pipeline_url,time_stamp,tag))
+        updated_file_content =  '| Pipeline ID |   Execution Time        | Release Version | Coverage (in %) |\n'
+        updated_file_content = updated_file_content + ('|---------|---------------------------|--------------|--------------|\n')
+        updated_file_content = updated_file_content + ('|    {}   |  {}           |  {}     |  {}     |\n'.format(pipeline_url,time_stamp,tag,totalCoverage))
         index = len(content_list)
         content_list.insert(index, updated_file_content)
         updated_file_content = ('\n').join(content_list)
     return file, updated_file_content
-
 file, updated_file_content = fetch_file_content()
 
 # github commit message 

--- a/vendor/github.com/onsi/gomega/go.mod
+++ b/vendor/github.com/onsi/gomega/go.mod
@@ -1,7 +1,5 @@
 module github.com/onsi/gomega
 
-go 1.14
-
 require (
 	github.com/fsnotify/fsnotify v1.4.7 // indirect
 	github.com/golang/protobuf v1.2.0
@@ -16,3 +14,4 @@ require (
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.2.4
 )
+

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2,13 +2,10 @@
 ## explicit
 cloud.google.com/go/compute/metadata
 # github.com/PuerkitoBio/purell v1.1.1
-## explicit
 github.com/PuerkitoBio/purell
 # github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
-## explicit
 github.com/PuerkitoBio/urlesc
 # github.com/davecgh/go-spew v1.1.1
-## explicit
 github.com/davecgh/go-spew/spew
 # github.com/emicklei/go-restful v2.12.0+incompatible
 ## explicit
@@ -17,7 +14,6 @@ github.com/emicklei/go-restful/log
 # github.com/fsnotify/fsnotify v1.4.8
 ## explicit
 # github.com/go-openapi/jsonpointer v0.19.3
-## explicit
 github.com/go-openapi/jsonpointer
 # github.com/go-openapi/jsonreference v0.19.3
 ## explicit
@@ -32,10 +28,7 @@ github.com/go-openapi/swag
 ## explicit
 github.com/gogo/protobuf/proto
 github.com/gogo/protobuf/sortkeys
-# github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
-## explicit
 # github.com/golang/protobuf v1.3.4
-## explicit
 github.com/golang/protobuf/proto
 github.com/golang/protobuf/ptypes
 github.com/golang/protobuf/ptypes/any
@@ -50,7 +43,6 @@ github.com/googleapis/gnostic/OpenAPIv2
 github.com/googleapis/gnostic/compiler
 github.com/googleapis/gnostic/extensions
 # github.com/hpcloud/tail v1.0.0
-## explicit
 github.com/hpcloud/tail
 github.com/hpcloud/tail/ratelimiter
 github.com/hpcloud/tail/util
@@ -73,7 +65,6 @@ github.com/mailru/easyjson/buffer
 github.com/mailru/easyjson/jlexer
 github.com/mailru/easyjson/jwriter
 # github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
-## explicit
 github.com/modern-go/concurrent
 # github.com/modern-go/reflect2 v1.0.1
 github.com/modern-go/reflect2
@@ -120,10 +111,7 @@ github.com/spf13/pflag
 # golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073
 ## explicit
 golang.org/x/crypto/ssh/terminal
-# golang.org/x/mod v0.2.0
-## explicit
 # golang.org/x/net v0.0.0-20200301022130-244492dfa37a
-## explicit
 golang.org/x/net/context
 golang.org/x/net/context/ctxhttp
 golang.org/x/net/html
@@ -134,18 +122,15 @@ golang.org/x/net/http2
 golang.org/x/net/http2/hpack
 golang.org/x/net/idna
 # golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
-## explicit
 golang.org/x/oauth2
 golang.org/x/oauth2/google
 golang.org/x/oauth2/internal
 golang.org/x/oauth2/jws
 golang.org/x/oauth2/jwt
 # golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527
-## explicit
 golang.org/x/sys/unix
 golang.org/x/sys/windows
 # golang.org/x/text v0.3.2
-## explicit
 golang.org/x/text/encoding
 golang.org/x/text/encoding/charmap
 golang.org/x/text/encoding/htmlindex
@@ -168,16 +153,13 @@ golang.org/x/text/unicode/bidi
 golang.org/x/text/unicode/norm
 golang.org/x/text/width
 # golang.org/x/time v0.0.0-20191024005414-555d28b269f0
-## explicit
 golang.org/x/time/rate
 # golang.org/x/tools v0.0.0-20200311090712-aafaee8bce8c
 ## explicit
 # golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
-## explicit
 golang.org/x/xerrors
 golang.org/x/xerrors/internal
 # google.golang.org/appengine v1.6.5
-## explicit
 google.golang.org/appengine
 google.golang.org/appengine/internal
 google.golang.org/appengine/internal/app_identity
@@ -191,13 +173,10 @@ google.golang.org/appengine/urlfetch
 # gopkg.in/fsnotify.v1 v1.4.7
 gopkg.in/fsnotify.v1
 # gopkg.in/inf.v0 v0.9.1
-## explicit
 gopkg.in/inf.v0
 # gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
-## explicit
 gopkg.in/tomb.v1
 # gopkg.in/yaml.v2 v2.2.8
-## explicit
 gopkg.in/yaml.v2
 # k8s.io/api v0.0.0-20190918195907-bd6ac527cfd2
 ## explicit


### PR DESCRIPTION
Signed-off-by: Udit Gaurav <udit.gaurav@mayadata.io>

**This PR is for:**

-  Add coverage percentage bar in readme and ci website

**Issue:**
- fixes: https://github.com/litmuschaos/litmus/issues/1748

**How are we updating the coverage percentage in Readme table:**

- We will get the coverage percentage from`e2e-metrics` job, then we will save it in some file called `coverage.txt` then in the `pipeline status update` job we will use this file to get the coverage value and add it in the readme file with a new column.
- Clicking on the coverage value will take us to the `.master-plan.yml` which is used to calculate the coverage.