### PR TITLE
feat(coverage): Add coverage percentage in readme for openebs

### DIFF
--- a/metrics/e2e-metrics
+++ b/metrics/e2e-metrics
@@ -27,8 +27,9 @@ sleep 50
 # Fetching coverage percentage from custom resource
 e2e_coverage_cr=$(kubectl get pcover -n $COVERAGE_NAMESPACE --no-headers | awk '{print $1}')
 kubectl get pcover $e2e_coverage_cr -n $COVERAGE_NAMESPACE -oyaml
-kubectl get pcover -n $COVERAGE_NAMESPACE -o=jsonpath='{.items[0].result.coverage}{"\n"}'
-sleep 5
+coverage_percentage=$(kubectl get pcover -n $COVERAGE_NAMESPACE -o=jsonpath='{.items[0].result.coverage}')
+echo "${coverage_percentage::-1}" >> coverage
+sleep 2
 
 #clean up
 kubectl delete -f e2e-metrics/deploy/rbac.yaml

--- a/pkg/utils/update.go
+++ b/pkg/utils/update.go
@@ -43,7 +43,7 @@ func UpdateResultTable(clientSet *chaosClient.LitmuschaosV1alpha1Client, experim
 }
 
 //UpdatePipelineStatus will update the status of pipeline at the end of all jobs
-func UpdatePipelineStatus() error {
+func UpdatePipelineStatus(coverageData string) error {
 
 	var out bytes.Buffer
 	var stderr bytes.Buffer
@@ -51,7 +51,7 @@ func UpdatePipelineStatus() error {
 	klog.Info("The pipeline id is:", os.Getenv("CI_PIPELINE_ID"))
 	klog.Info("The release tag for running pipeline is:", chaosTypes.ExperimentImageTag)
 	// Recording job number for pipeline update
-	cmd := exec.Command("python3", "-u", "../utils/pipeline_status_update.py", "--pipeline_id", os.Getenv("CI_PIPELINE_ID"), "--tag", chaosTypes.ExperimentImageTag, "--time_stamp", (time.Now().Format(time.ANSIC))+"(IST)", "--token", os.Getenv("GITHUB_TOKEN"))
+	cmd := exec.Command("python3", "-u", "../utils/pipeline_status_update.py", "--pipeline_id", os.Getenv("CI_PIPELINE_ID"), "--tag", chaosTypes.ExperimentImageTag, "--time_stamp", (time.Now().Format(time.ANSIC))+"(IST)", "--coverage", coverageData, "--token", os.Getenv("GITHUB_TOKEN"))
 	cmd.Stdout = &out
 	cmd.Stderr = &stderr
 	err = cmd.Run()

--- a/tests/pipeline-status-update_test.go
+++ b/tests/pipeline-status-update_test.go
@@ -1,7 +1,9 @@
- 
 package tests
 
 import (
+	"fmt"
+	"io/ioutil"
+	"strings"
 	"testing"
 
 	"github.com/litmuschaos/litmus-e2e/pkg/utils"
@@ -28,7 +30,13 @@ var _ = Describe("BDD of pipeline status update", func() {
 			//Updating the pipeline status table
 			By("Updating the pipeline status table")
 			var err error
-			err = utils.UpdatePipelineStatus()
+			coverageData, err := ioutil.ReadFile("../coverage")
+			if err != nil {
+				klog.Infof("failed reading coverageData from file: %s", err)
+			}
+			lines := strings.Split(string(coverageData), "\n")
+			fmt.Printf("\nFile Content: %s\n", string(lines[0]))
+			err = utils.UpdatePipelineStatus(string(lines[0]))
 			Expect(err).To(BeNil(), "Fail run the script for pipeline status updation")
 			klog.Info("Pipeline status updated successfully !!!")
 

--- a/utils/pipeline_status_update.py
+++ b/utils/pipeline_status_update.py
@@ -13,6 +13,9 @@ parser = argparse.ArgumentParser()
 parser.add_argument("--pipeline_id",
        help="gitlab pipeline id to create gitlab pipeline_url")
 
+parser.add_argument("--coverage",
+       help="getting the pipeline coverage")
+
 parser.add_argument("--tag",
        help="gitlab pipeline release tag")
 
@@ -24,6 +27,7 @@ parser.add_argument("--token",
 
 args = parser.parse_args()
 pipeline_id = args.pipeline_id
+coverage = args.coverage
 tag = args.tag
 time_stamp = args.time_stamp
 token = args.token
@@ -47,24 +51,24 @@ def fetch_file_content():
     file = repo.get_contents(file_path, "master")
     file_content=str(file.decoded_content, 'utf-8')
     content_list = file_content.split('\n')
+    totalCoverage= '[!['+coverage+'%](https://progress-bar.dev/'+coverage+')](https://bit.ly/396abMB)'
 
     # updating result's table if the table is already there
     if file_content.find('|')>0:
-        new_pipeline = '|     {}           |  {}           | {}  |'.format(pipeline_url,time_stamp,tag)
-        index = content_list.index('| Pipeline ID |   Execution Time        | Release Version |')
+        new_pipeline = '|     {}           |  {}           | {}  | {}  |'.format(pipeline_url,time_stamp,tag,totalCoverage)
+        index = content_list.index('| Pipeline ID |   Execution Time        | Release Version | Coverage (in %) |')
         content_list.insert(index+2,new_pipeline)
         updated_file_content = ('\n').join(content_list)
 
     # creating result's table for first pipeline result entry 
     else:
-        updated_file_content =  '| Pipeline ID |   Execution Time        | Release Version |\n'
-        updated_file_content = updated_file_content + ('|---------|---------------------------| --------------|\n')
-        updated_file_content = updated_file_content + ('|    {}   |  {}           |  {}     |\n'.format(pipeline_url,time_stamp,tag))
+        updated_file_content =  '| Pipeline ID |   Execution Time        | Release Version | Coverage (in %) |\n'
+        updated_file_content = updated_file_content + ('|---------|---------------------------|--------------|--------------|\n')
+        updated_file_content = updated_file_content + ('|    {}   |  {}           |  {}     |  {}     |\n'.format(pipeline_url,time_stamp,tag,totalCoverage))
         index = len(content_list)
         content_list.insert(index, updated_file_content)
         updated_file_content = ('\n').join(content_list)
     return file, updated_file_content
-
 file, updated_file_content = fetch_file_content()
 
 # github commit message 


### PR DESCRIPTION
Signed-off-by: Udit Gaurav <udit.gaurav@mayadata.io>

**This PR is for:**

- Add coverage percentage in the readme for openebs

**Issue:**
- fixes: litmuschaos/litmus#1748

**How are we updating the coverage percentage in Readme table:**

- We will get the coverage percentage from`e2e-metrics` job, then we will save it in some file called `coverage.txt` then in the `pipeline status update` job we will use this file to get the coverage value and add it in the readme file with a new column.
- Clicking on the coverage value will take us to the `.master-plan.yml` which is used to calculate the coverage.