### PR TITLE
Upgraded the Cypress Version, Changed the headless browser to Chrome …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .vscode
 **/node_modules/
+**/results
+**/videos
+**/screenshots

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,7 +30,7 @@ Cluster Connect:
 
 Cypress-e2e:
   when: always
-  image: cypress/base:10
+  image: cypress/browsers:latest
   stage: cypress-test
   tags:
     - litmus-portal

--- a/CypressE2E/cypress.json
+++ b/CypressE2E/cypress.json
@@ -3,8 +3,5 @@
     "experimentalFetchPolyfill": true,
     "viewportWidth": 1800,
     "viewportHeight": 1200,
-    "reporter": "junit",
-    "reporterOptions": {
-        "mochaFile": "results/Test-[hash].xml"
-    }
+    "defaultCommandTimeout": 10000
 }

--- a/CypressE2E/cypress/integration/Login/login.spec.js
+++ b/CypressE2E/cypress/integration/Login/login.spec.js
@@ -19,16 +19,16 @@ describe("Checking functionality of Login Page",()=>{
   
     it("Checking Input areas functionallity",()=>{
         cy.login("Vedant","Litmus");
-        cy.get("[data-cy=inputEmail] input").should("have.value","Vedant");
-        cy.get("[data-cy=inputPassword] input").should("have.value","Litmus");
+        cy.get("[name=username]").should("have.value","Vedant");
+        cy.get("[name=password]").should("have.value","Litmus");
     })
 
     it("Testing the only single input sign in [ Should not be possible ]",()=>{
         cy.loginServer(503);
         cy.login("Vedant"," ");
         cy.url().should('include','/login');
-        cy.get('[data-cy=inputEmail] input').clear();
-        cy.get('[data-cy=inputPassword] input').clear();
+        cy.get('[name=username]').clear();
+        cy.get('[name=password]').clear();
         cy.login(" ","Litmus");
         cy.url().should('include','/login');
     })

--- a/CypressE2E/cypress/support/commands.js
+++ b/CypressE2E/cypress/support/commands.js
@@ -38,7 +38,7 @@ Cypress.Commands.add('welcomeModalInputs',(ProjectName,Email,Password)=>{
 
 //Command for inputting details and login.
 Cypress.Commands.add('login',(Email,password)=>{
-    cy.get('[data-cy=inputEmail] input').type(Email);
-    cy.get('[data-cy=inputPassword] input').type(password);
+    cy.get('[name=username]').type(Email);
+    cy.get('[name=password]').type(password);
     cy.get('[data-cy=loginButton]').click();
 })

--- a/CypressE2E/cypress/support/index.js
+++ b/CypressE2E/cypress/support/index.js
@@ -3,9 +3,9 @@ import './commands'
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
-Cypress.on('uncaught:exception', (err, runnable) => {
-    // returning false here prevents Cypress from
-    // failing the test
-    return false
-})
+// Cypress.on('uncaught:exception', (err, runnable) => {
+//     // returning false here prevents Cypress from
+//     // failing the test
+//     return false
+// })
 

--- a/CypressE2E/package-lock.json
+++ b/CypressE2E/package-lock.json
@@ -483,9 +483,9 @@
       }
     },
     "cypress": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-4.10.0.tgz",
-      "integrity": "sha512-eFv1WPp4zFrAgZ6mwherBGVsTpHvay/hEF5F7U7yfAkTxsUQn/ZG/LdX67fIi3bKDTQXYzFv/CvywlQSeug8Bg==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-4.11.0.tgz",
+      "integrity": "sha512-6Yd598+KPATM+dU1Ig0g2hbA+R/o1MAKt0xIejw4nZBVLSplCouBzqeKve6XsxGU6n4HMSt/+QYsWfFcoQeSEw==",
       "dev": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "0.4.1",
@@ -512,7 +512,7 @@
         "is-installed-globally": "0.3.2",
         "lazy-ass": "1.6.0",
         "listr": "0.14.3",
-        "lodash": "4.17.15",
+        "lodash": "4.17.19",
         "log-symbols": "3.0.0",
         "minimist": "1.2.5",
         "moment": "2.26.0",
@@ -1130,9 +1130,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
     "lodash.once": {

--- a/CypressE2E/package.json
+++ b/CypressE2E/package.json
@@ -4,7 +4,7 @@
   "description": "Package for Testing",
   "main": "index.js",
   "scripts": {
-    "test": "wait-on http://localhost:3000 && cypress run"
+    "test": "wait-on http://localhost:3000 && cypress run --headless --browser=chrome"
   },
   "keywords": [
     "Testing",
@@ -13,7 +13,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "cypress": "^4.10.0",
+    "cypress": "^4.11.0",
     "wait-on": "^5.1.0"
   }
 }


### PR DESCRIPTION
In this PR,

- Cypress Version is upgraded from 4.10.0 to 4.11.0.

- Cypress Docker Image changed to include Chrome headless browser.

- Timeout time for Cypress commands is increased.