### PR TITLE
Added a Smaller docker Image for Cypress.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,8 +1,8 @@
 ---
 stages:
-  # - setup
+  - setup
   - cypress-test
-  # - cleanup
+  - cleanup
 
 
 variables:
@@ -16,24 +16,24 @@ cache:
     - CypressE2E/cache/Cypress
     - CypressE2E/node_modules
 
-# Cluster Connect:
-#   stage: setup
-#   tags:
-#     - litmus-portal
-#   script:
-#     - chmod 755 ./build/gitlab/stages/3-cluster-connect/cluster-connect
-#     - ./build/gitlab/stages/3-cluster-connect/cluster-connect
-#   artifacts:
-#     when: always
-#     paths:
-#       - .kube/
+Cluster Connect:
+  stage: setup
+  tags:
+    - litmus-portal
+  script:
+    - chmod 755 ./build/gitlab/stages/3-cluster-connect/cluster-connect
+    - ./build/gitlab/stages/3-cluster-connect/cluster-connect
+  artifacts:
+    when: always
+    paths:
+      - .kube/
 
 Cypress-e2e:
   when: always
   image: cypress/base:10
   stage: cypress-test
-  # tags:
-  #   - litmus-portal
+  tags:
+    - litmus-portal
   script:
     - cd CypressE2E && npm ci
     - cd ../ && git clone -b litmus-portal https://github.com/litmuschaos/litmus.git
@@ -48,16 +48,16 @@ Cypress-e2e:
       - CypressE2E/cypress/videos
       - .kube/
 
-# Cluster Disconnect:
-#   when: always
-#   stage: cleanup
-#   tags:
-#     - litmus-portal
-#   script: 
-#     - chmod 755 ./build/gitlab/stages/4-cluster-disconnect/cluster-disconnect
-#     - ./build/gitlab/stages/4-cluster-disconnect/cluster-disconnect
-#   artifacts:
-#     when: always
-#     paths:
-#       - .kube/
+Cluster Disconnect:
+  when: always
+  stage: cleanup
+  tags:
+    - litmus-portal
+  script: 
+    - chmod 755 ./build/gitlab/stages/4-cluster-disconnect/cluster-disconnect
+    - ./build/gitlab/stages/4-cluster-disconnect/cluster-disconnect
+  artifacts:
+    when: always
+    paths:
+      - .kube/
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,8 +1,8 @@
 ---
 stages:
-  - setup
+  # - setup
   - cypress-test
-  - cleanup
+  # - cleanup
 
 
 variables:
@@ -16,24 +16,24 @@ cache:
     - CypressE2E/cache/Cypress
     - CypressE2E/node_modules
 
-Cluster Connect:
-  stage: setup
-  tags:
-    - litmus-portal
-  script:
-    - chmod 755 ./build/gitlab/stages/3-cluster-connect/cluster-connect
-    - ./build/gitlab/stages/3-cluster-connect/cluster-connect
-  artifacts:
-    when: always
-    paths:
-      - .kube/
+# Cluster Connect:
+#   stage: setup
+#   tags:
+#     - litmus-portal
+#   script:
+#     - chmod 755 ./build/gitlab/stages/3-cluster-connect/cluster-connect
+#     - ./build/gitlab/stages/3-cluster-connect/cluster-connect
+#   artifacts:
+#     when: always
+#     paths:
+#       - .kube/
 
 Cypress-e2e:
   when: always
-  image: cypress/browsers:latest
+  image: cypress/base:10
   stage: cypress-test
-  tags:
-    - litmus-portal
+  # tags:
+  #   - litmus-portal
   script:
     - cd CypressE2E && npm ci
     - cd ../ && git clone -b litmus-portal https://github.com/litmuschaos/litmus.git
@@ -48,16 +48,16 @@ Cypress-e2e:
       - CypressE2E/cypress/videos
       - .kube/
 
-Cluster Disconnect:
-  when: always
-  stage: cleanup
-  tags:
-    - litmus-portal
-  script: 
-    - chmod 755 ./build/gitlab/stages/4-cluster-disconnect/cluster-disconnect
-    - ./build/gitlab/stages/4-cluster-disconnect/cluster-disconnect
-  artifacts:
-    when: always
-    paths:
-      - .kube/
+# Cluster Disconnect:
+#   when: always
+#   stage: cleanup
+#   tags:
+#     - litmus-portal
+#   script: 
+#     - chmod 755 ./build/gitlab/stages/4-cluster-disconnect/cluster-disconnect
+#     - ./build/gitlab/stages/4-cluster-disconnect/cluster-disconnect
+#   artifacts:
+#     when: always
+#     paths:
+#       - .kube/
 

--- a/CypressE2E/package.json
+++ b/CypressE2E/package.json
@@ -4,7 +4,7 @@
   "description": "Package for Testing",
   "main": "index.js",
   "scripts": {
-    "test": "wait-on http://localhost:3000 && cypress run --headless --browser=chrome"
+    "test": "wait-on http://localhost:3000 && cypress run"
   },
   "keywords": [
     "Testing",
@@ -13,7 +13,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "cypress": "^4.11.0",
+    "cypress": "^4.10.0",
     "wait-on": "^5.1.0"
   }
 }


### PR DESCRIPTION
Added a smaller docker image Cypress/base:10 in place of Cypress/browsers as Cypress/browsers image was occupying large space on the runner. Now the size of Cypress/base is around 400 MB.
The Version is still upgraded one i.e. 4.11.0.