### PR TITLE
feat(experiment): Add Node Selector values for infra engine

### DIFF
--- a/ansible/ansible-kubelet-service-kill_test.go
+++ b/ansible/ansible-kubelet-service-kill_test.go
@@ -29,7 +29,7 @@ var _ = Describe("BDD of kubelet-service-kill experiment", func() {
 
 			testsDetails := types.TestDetails{}
 			clients := environment.ClientSets{}
-
+			var err error
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
 			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
@@ -52,6 +52,11 @@ var _ = Describe("BDD of kubelet-service-kill experiment", func() {
 			By("[Prepare]: Getting application node name")
 			if _, err := pkg.GetApplicationNode(&testsDetails, clients); err != nil {
 				log.Fatalf("Unable to get application node name, due to %v", err)
+			}
+
+			// Getting other node for nodeSelector in engine
+			if testsDetails.NodeSelectorName, err = pkg.GetSelectorNode(&testsDetails, clients); err != nil || testsDetails.NodeSelectorName == "" {
+				log.Fatalf("Unable to get node name for node selector, due to %v", err)
 			}
 
 			//Cordon the application node

--- a/ansible/ansible-node-drain_test.go
+++ b/ansible/ansible-node-drain_test.go
@@ -29,7 +29,7 @@ var _ = Describe("BDD of node-drain experiment", func() {
 
 			testsDetails := types.TestDetails{}
 			clients := environment.ClientSets{}
-
+			var err error
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
 			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
@@ -52,6 +52,11 @@ var _ = Describe("BDD of node-drain experiment", func() {
 			By("[Prepare]: Getting application node name")
 			if _, err := pkg.GetApplicationNode(&testsDetails, clients); err != nil {
 				log.Fatalf("Unable to get application node name, due to %v", err)
+			}
+
+			// Getting other node for nodeSelector in engine
+			if testsDetails.NodeSelectorName, err = pkg.GetSelectorNode(&testsDetails, clients); err != nil || testsDetails.NodeSelectorName == "" {
+				log.Fatalf("Unable to get node name for node selector, due to %v", err)
 			}
 
 			//Cordon the application node

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -18,6 +18,7 @@ func GetENV(testDetails *types.TestDetails, expName, engineName string) {
 	testDetails.JobCleanUpPolicy = Getenv("JOB_CLEANUP_POLICY", "'retain'")
 	testDetails.AnnotationCheck = Getenv("ANNOTATION_CHECK", "false")
 	testDetails.ApplicationNodeName = Getenv("APPLICATION_NODE_NAME", "")
+	testDetails.NodeSelectorName = Getenv("APPLICATION_NODE_NAME", "")
 	testDetails.ImagePullPolicy = Getenv("IMAGE_PULL_POLICY", "Always")
 	testDetails.ChaosDuration, _ = strconv.Atoi(Getenv("TOTAL_CHAOS_DURATION", ""))
 

--- a/pkg/get.go
+++ b/pkg/get.go
@@ -28,3 +28,18 @@ func GetChaosEngineVerdict(testsDetails *types.TestDetails, clients environment.
 	}
 	return string(chaosEngine.Status.Experiments[0].Verdict), nil
 }
+
+// GetSelectorNode will return a node other than the application node selected for using in node selector in chaos engine spec
+func GetSelectorNode(testsDetails *types.TestDetails, clients environment.ClientSets) (string, error) {
+	nodes, err := clients.KubeClient.CoreV1().Nodes().List(metav1.ListOptions{})
+	if err != nil || len(nodes.Items) == 0 {
+		return "", errors.Errorf("Fail to get nodes, due to %v", err)
+	}
+
+	for _, node := range nodes.Items {
+		if node.Name != testsDetails.ApplicationNodeName {
+			return string(node.Name), nil
+		}
+	}
+	return "", nil
+}

--- a/pkg/install.go
+++ b/pkg/install.go
@@ -109,8 +109,11 @@ func InstallAnsibleChaosEngine(testsDetails *types.TestDetails, engineNamespace 
 		}
 	}
 
-	if testsDetails.ExperimentName == "node-drain" || testsDetails.ExperimentName == "kubelet-service-kill" {
+	if testsDetails.ApplicationNodeName != "" {
 		if err = EditKeyValue(testsDetails.ExperimentName+"-ce.yaml", "APP_NODE", "value: 'node-01'", "value: '"+testsDetails.ApplicationNodeName+"'"); err != nil {
+			return errors.Errorf("Fail to Update the engine file, due to %v", err)
+		}
+		if err = EditFile(testsDetails.ExperimentName+"-ce.yaml", "kubernetes.io/hostname: 'node02'", "kubernetes.io/hostname: '"+testsDetails.NodeSelectorName+"'"); err != nil {
 			return errors.Errorf("Fail to Update the engine file, due to %v", err)
 		}
 	}
@@ -222,8 +225,11 @@ func InstallGoChaosEngine(testsDetails *types.TestDetails, engineNamespace strin
 			return errors.Errorf("Fail to Update the engine file, due to %v", err)
 		}
 	}
-	if testsDetails.ExperimentName == "node-drain" || testsDetails.ExperimentName == "node-taint" || testsDetails.ExperimentName == "kubelet-service-kill" {
+	if testsDetails.ApplicationNodeName != "" {
 		if err = EditKeyValue(testsDetails.ExperimentName+"-ce.yaml", "APP_NODE", "value: 'node-01'", "value: '"+testsDetails.ApplicationNodeName+"'"); err != nil {
+			return errors.Errorf("Fail to Update the engine file, due to %v", err)
+		}
+		if err = EditFile(testsDetails.ExperimentName+"-ce.yaml", "kubernetes.io/hostname: 'node02'", "kubernetes.io/hostname: '"+testsDetails.NodeSelectorName+"'"); err != nil {
 			return errors.Errorf("Fail to Update the engine file, due to %v", err)
 		}
 	}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -25,4 +25,5 @@ type TestDetails struct {
 	RunnerImage            string
 	ChaosDuration          int
 	AdminRbacPath          string
+	NodeSelectorName       string
 }

--- a/tests/kubelet-service-kill_test.go
+++ b/tests/kubelet-service-kill_test.go
@@ -30,6 +30,7 @@ var _ = Describe("BDD of kubelet-service-kill experiment", func() {
 			testsDetails := types.TestDetails{}
 			clients := environment.ClientSets{}
 
+			var err error
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
 			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
@@ -52,6 +53,11 @@ var _ = Describe("BDD of kubelet-service-kill experiment", func() {
 			By("[Prepare]: Getting application node name")
 			if _, err := pkg.GetApplicationNode(&testsDetails, clients); err != nil {
 				log.Fatalf("Unable to get application node name, due to %v", err)
+			}
+
+			// Getting other node for nodeSelector in engine
+			if testsDetails.NodeSelectorName, err = pkg.GetSelectorNode(&testsDetails, clients); err != nil || testsDetails.NodeSelectorName == "" {
+				log.Fatalf("Unable to get node name for node selector, due to %v", err)
 			}
 
 			//Cordon the application node

--- a/tests/node-drain_test.go
+++ b/tests/node-drain_test.go
@@ -29,7 +29,7 @@ var _ = Describe("BDD of node-drain experiment", func() {
 
 			testsDetails := types.TestDetails{}
 			clients := environment.ClientSets{}
-
+			var err error
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
 			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
@@ -52,6 +52,11 @@ var _ = Describe("BDD of node-drain experiment", func() {
 			By("[Prepare]: Getting application node name")
 			if _, err := pkg.GetApplicationNode(&testsDetails, clients); err != nil {
 				log.Fatalf("Unable to get application node name, due to %v", err)
+			}
+
+			// Getting other node for nodeSelector in engine
+			if testsDetails.NodeSelectorName, err = pkg.GetSelectorNode(&testsDetails, clients); err != nil || testsDetails.NodeSelectorName == "" {
+				log.Fatalf("Unable to get node name for node selector, due to %v", err)
 			}
 
 			//Cordon the application node

--- a/tests/node-taint_test.go
+++ b/tests/node-taint_test.go
@@ -29,7 +29,7 @@ var _ = Describe("BDD of node-taint experiment", func() {
 
 			testsDetails := types.TestDetails{}
 			clients := environment.ClientSets{}
-
+			var err error
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
 			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
@@ -52,6 +52,11 @@ var _ = Describe("BDD of node-taint experiment", func() {
 			By("[Prepare]: Getting application node name")
 			if _, err := pkg.GetApplicationNode(&testsDetails, clients); err != nil {
 				log.Fatalf("Unable to get application node name, due to %v", err)
+			}
+
+			// Getting other node for nodeSelector in engine
+			if testsDetails.NodeSelectorName, err = pkg.GetSelectorNode(&testsDetails, clients); err != nil || testsDetails.NodeSelectorName == "" {
+				log.Fatalf("Unable to get node name for node selector, due to %v", err)
 			}
 
 			//Cordon the application node


### PR DESCRIPTION
Signed-off-by: Udit Gaurav <udit.gaurav@mayadata.io>

**What does this PR do/why do we need it?**

- Add Node Selector values for infra engine

This is due to spec changes in chaosengine:

```yaml
spec:
   components:
       nodeSelector: 
            kubernetes.io/hostname: 'node02'   
```
