### PR TITLE
chore(bdd): Convert log.Fatalf to Execpt in all BDDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -280,7 +280,7 @@ go-experiment-cleanup:
 ansible-pod-delete:
 
 	@echo "-------------------------------------"
-	@echo "Running Ansible Pod Delete Experiemnt"
+	@echo "Running Ansible Pod Delete Experiment"
 	@echo "-------------------------------------"
 	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
 	 "$(EXPORT_VARIABLES)  && go test $(TESTPATH)/ansible/ansible-pod-delete_test.go -v -count=1"
@@ -289,7 +289,7 @@ ansible-pod-delete:
 ansible-container-kill:
 
 	@echo "-------------------------------------"
-	@echo "Running Ansible Container Kill Experiemnt"
+	@echo "Running Ansible Container Kill Experiment"
 	@echo "-------------------------------------"
 	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
 	 "$(EXPORT_VARIABLES)  && go test $(TESTPATH)/ansible/ansible-container-kill_test.go -v -count=1"
@@ -298,7 +298,7 @@ ansible-container-kill:
 ansible-disk-fill:
 
 	@echo "-------------------------------------"
-	@echo "Running Ansible disk fill Experiemnt"
+	@echo "Running Ansible disk fill Experiment"
 	@echo "-------------------------------------"
 	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
 	 "$(EXPORT_VARIABLES)  && go test $(TESTPATH)/ansible/ansible-disk-fill_test.go -v -count=1"
@@ -307,7 +307,7 @@ ansible-disk-fill:
 ansible-node-cpu-hog:
 
 	@echo "---------------------------------------"
-	@echo "Running Ansible Node CPU Hog Experiemnt"
+	@echo "Running Ansible Node CPU Hog Experiment"
 	@echo "---------------------------------------"
 	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
 	 "$(EXPORT_VARIABLES)  && go test $(TESTPATH)/ansible/ansible-node-cpu-hog_test.go -v -count=1"
@@ -316,7 +316,7 @@ ansible-node-cpu-hog:
 ansible-node-memory-hog:
 
 	@echo "------------------------------------------"
-	@echo "Running Ansible Node Memory Hog Experiemnt"
+	@echo "Running Ansible Node Memory Hog Experiment"
 	@echo "------------------------------------------"
 	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
 	 "$(EXPORT_VARIABLES)  && go test $(TESTPATH)/ansible/ansible-node-memory-hog_test.go -v -count=1"
@@ -325,7 +325,7 @@ ansible-node-memory-hog:
 ansible-pod-cpu-hog:
 
 	@echo "--------------------------------------"
-	@echo "Running Ansible Pod CPU Hog Experiemnt"
+	@echo "Running Ansible Pod CPU Hog Experiment"
 	@echo "--------------------------------------"
 	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
 	 "$(EXPORT_VARIABLES)  && go test $(TESTPATH)/ansible/ansible-pod-cpu-hog_test.go -v -count=1"
@@ -334,7 +334,7 @@ ansible-pod-cpu-hog:
 ansible-pod-memory-hog:
 
 	@echo "-----------------------------------------"
-	@echo "Running Ansible Pod Memory Hog Experiemnt"
+	@echo "Running Ansible Pod Memory Hog Experiment"
 	@echo "-----------------------------------------"
 	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
 	 "$(EXPORT_VARIABLES)  && go test $(TESTPATH)/ansible/ansible-pod-memory-hog_test.go -v -count=1"
@@ -343,7 +343,7 @@ ansible-pod-memory-hog:
 ansible-pod-network-corruption:
 
 	@echo "-------------------------------------------------"
-	@echo "Running Ansible Pod Network Corruption Experiemnt"
+	@echo "Running Ansible Pod Network Corruption Experiment"
 	@echo "-------------------------------------------------"
 	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
 	 "$(EXPORT_VARIABLES)  && go test $(TESTPATH)/ansible/ansible-pod-network-corruption_test.go -v -count=1"
@@ -352,7 +352,7 @@ ansible-pod-network-corruption:
 ansible-pod-network-latency:
 
 	@echo "----------------------------------------------"
-	@echo "Running Ansible Pod Network Latency Experiemnt"
+	@echo "Running Ansible Pod Network Latency Experiment"
 	@echo "----------------------------------------------"
 	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
 	 "$(EXPORT_VARIABLES)  && go test $(TESTPATH)/ansible/ansible-pod-network-latency_test.go -v -count=1"
@@ -362,7 +362,7 @@ ansible-pod-network-latency:
 ansible-pod-network-loss:
 
 	@echo "-------------------------------------------"
-	@echo "Running Ansible Pod Network Loss Experiemnt"
+	@echo "Running Ansible Pod Network Loss Experiment"
 	@echo "-------------------------------------------"
 	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
 	 "$(EXPORT_VARIABLES)  && go test $(TESTPATH)/ansible/ansible-pod-network-loss_test.go -v -count=1"
@@ -372,7 +372,7 @@ ansible-pod-network-loss:
 ansible-kubelet-service-kill:
 
 	@echo "-----------------------------------------------"
-	@echo "Running Ansible Kubelet Service Kill Experiemnt"
+	@echo "Running Ansible Kubelet Service Kill Experiment"
 	@echo "-----------------------------------------------"
 	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
 	 "$(EXPORT_VARIABLES)  && go test $(TESTPATH)/ansible/ansible-kubelet-service-kill_test.go -v -count=1"
@@ -382,7 +382,7 @@ ansible-kubelet-service-kill:
 ansible-node-drain:
 
 	@echo "-------------------------------------"
-	@echo "Running Ansible Node Drain Experiemnt"
+	@echo "Running Ansible Node Drain Experiment"
 	@echo "-------------------------------------"
 	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
 	 "$(EXPORT_VARIABLES)  && go test $(TESTPATH)/ansible/ansible-node-drain_test.go -v -count=1"	

--- a/ansible/ansible-container-kill_test.go
+++ b/ansible/ansible-container-kill_test.go
@@ -1,7 +1,6 @@
 package ansible
 
 import (
-	"log"
 	"testing"
 
 	"github.com/litmuschaos/litmus-e2e/pkg"
@@ -29,11 +28,11 @@ var _ = Describe("BDD of container-kill experiment", func() {
 			testsDetails := types.TestDetails{}
 			clients := environment.ClientSets{}
 
+			var err error
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				klog.Infof("Unable to Get the kubeconfig due to %v", err)
-			}
+			err = clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig due to {%v}", err)
 
 			//Fetching all the default ENV
 			//Note: please don't provide custom experiment name here
@@ -43,46 +42,39 @@ var _ = Describe("BDD of container-kill experiment", func() {
 
 			// Checking the chaos operator running status
 			By("[Status]: Checking chaos operator status")
-			if err := pkg.OperatorStatusCheck(&testsDetails, clients); err != nil {
-				log.Fatalf("Operator status check failed, due to %v", err)
-			}
+			err = pkg.OperatorStatusCheck(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Operator status check failed, due to {%v}", err)
 
 			//Installing RBAC for the experiment
 			By("[Install]: Installing RBAC")
-			if err := pkg.InstallAnsibleRbac(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install rbac, due to %v", err)
-			}
+			err = pkg.InstallAnsibleRbac(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install rbac, due to {%v}", err)
 
 			//Installing Chaos Experiment for container-kill
 			By("[Install]: Installing chaos experiment")
-			if err := pkg.InstallAnsibleChaosExperiment(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaos experiment, due to %v", err)
-			}
+			err = pkg.InstallAnsibleChaosExperiment(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos experiment, due to {%v}", err)
 
 			//Installing Chaos Engine for container-kill
 			By("[Install]: Installing chaos engine")
-			if err := pkg.InstallAnsibleChaosEngine(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaosengine, due to %v", err)
-			}
+			err = pkg.InstallAnsibleChaosEngine(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos engine, due to {%v}", err)
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			if _, err := pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Runner pod status check failed, due to %v", err)
-			}
+			_, err = pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Waiting for experiment job to get completed
 			//And Print the logs of the job pod (chaos pod)
 			By("[Status]: Wait for job completion and then print logs")
-			if _, err := pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Fail to get the experiment job pod logs, due to %v", err)
-			}
+			_, err = pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Fail to get the experiment job pod logs, due to {%v}", err)
 
 			//Checking the chaosresult verdict
 			By("[Verdict]: Checking the chaosresult verdict")
-			if _, err := pkg.ChaosResultVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChasoResult Verdict check failed, due to %v", err)
-			}
+			_, err = pkg.ChaosResultVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 
 		})
 	})
@@ -96,9 +88,8 @@ var _ = Describe("BDD of container-kill experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				log.Fatalf("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig due to {%v}", err)
 
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")
@@ -107,9 +98,8 @@ var _ = Describe("BDD of container-kill experiment", func() {
 
 			//Checking chaosengine verdict
 			By("Checking the Verdict of Chaos Engine")
-			if _, err := pkg.ChaosEngineVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChaosEngine Verdict check failed, due to %v", err)
-			}
+			_, err = pkg.ChaosEngineVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
 
 		})
 	})

--- a/ansible/ansible-disk-fill_test.go
+++ b/ansible/ansible-disk-fill_test.go
@@ -1,7 +1,6 @@
 package ansible
 
 import (
-	"log"
 	"testing"
 
 	"github.com/litmuschaos/litmus-e2e/pkg"
@@ -29,11 +28,11 @@ var _ = Describe("BDD of disk-fill experiment", func() {
 			testsDetails := types.TestDetails{}
 			clients := environment.ClientSets{}
 
+			var err error
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				klog.Infof("Unable to Get the kubeconfig due to %v", err)
-			}
+			err = clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig due to {%v}", err)
 
 			//Fetching all the default ENV
 			//Note: please don't provide custom experiment name here
@@ -43,46 +42,39 @@ var _ = Describe("BDD of disk-fill experiment", func() {
 
 			// Checking the chaos operator running status
 			By("[Status]: Checking chaos operator status")
-			if err := pkg.OperatorStatusCheck(&testsDetails, clients); err != nil {
-				log.Fatalf("Operator status check failed, due to %v", err)
-			}
+			err = pkg.OperatorStatusCheck(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Operator status check failed, due to {%v}", err)
 
 			//Installing RBAC for the experiment
 			By("[Install]: Installing RBAC")
-			if err := pkg.InstallAnsibleRbac(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install rbac, due to %v", err)
-			}
+			err = pkg.InstallAnsibleRbac(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install rbac, due to {%v}", err)
 
 			//Installing Chaos Experiment for disk-fill
 			By("[Install]: Installing chaos experiment")
-			if err := pkg.InstallAnsibleChaosExperiment(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaos experiment, due to %v", err)
-			}
+			err = pkg.InstallAnsibleChaosExperiment(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos experiment, due to {%v}", err)
 
 			//Installing Chaos Engine for disk-fill
 			By("[Install]: Installing chaos engine")
-			if err := pkg.InstallAnsibleChaosEngine(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaosengine, due to %v", err)
-			}
+			err = pkg.InstallAnsibleChaosEngine(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos engine, due to {%v}", err)
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			if _, err := pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Runner pod status check failed, due to %v", err)
-			}
+			_, err = pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Waiting for experiment job to get completed
 			//And Print the logs of the job pod (chaos pod)
 			By("[Status]: Wait for job completion and then print logs")
-			if _, err := pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Fail to get the experiment job pod logs, due to %v", err)
-			}
+			_, err = pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Fail to get the experiment job pod logs, due to {%v}", err)
 
 			//Checking the chaosresult verdict
 			By("[Verdict]: Checking the chaosresult verdict")
-			if _, err := pkg.ChaosResultVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChasoResult Verdict check failed, due to %v", err)
-			}
+			_, err = pkg.ChaosResultVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 
 		})
 	})
@@ -96,9 +88,8 @@ var _ = Describe("BDD of disk-fill experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				log.Fatalf("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig due to {%v}", err)
 
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")
@@ -107,9 +98,8 @@ var _ = Describe("BDD of disk-fill experiment", func() {
 
 			//Checking chaosengine verdict
 			By("Checking the Verdict of Chaos Engine")
-			if _, err := pkg.ChaosEngineVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChaosEngine Verdict check failed, due to %v", err)
-			}
+			_, err = pkg.ChaosEngineVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
 
 		})
 	})

--- a/ansible/ansible-kubelet-service-kill_test.go
+++ b/ansible/ansible-kubelet-service-kill_test.go
@@ -1,7 +1,6 @@
 package ansible
 
 import (
-	"log"
 	"testing"
 
 	"github.com/litmuschaos/litmus-e2e/pkg"
@@ -30,11 +29,11 @@ var _ = Describe("BDD of kubelet-service-kill experiment", func() {
 			testsDetails := types.TestDetails{}
 			clients := environment.ClientSets{}
 			var err error
+
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				klog.Infof("Unable to Get the kubeconfig due to %v", err)
-			}
+			err = clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig due to {%v}", err)
 
 			//Fetching all the default ENV
 			//Note: please don't provide custom experiment name here
@@ -44,69 +43,79 @@ var _ = Describe("BDD of kubelet-service-kill experiment", func() {
 
 			// Checking the chaos operator running status
 			By("[Status]: Checking chaos operator status")
-			if err := pkg.OperatorStatusCheck(&testsDetails, clients); err != nil {
-				log.Fatalf("Operator status check failed, due to %v", err)
-			}
+			err = pkg.OperatorStatusCheck(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Operator status check failed, due to {%v}", err)
 
 			// Getting application node name
 			By("[Prepare]: Getting application node name")
-			if _, err := pkg.GetApplicationNode(&testsDetails, clients); err != nil {
-				log.Fatalf("Unable to get application node name, due to %v", err)
-			}
+			_, err = pkg.GetApplicationNode(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Unable to get application node name due to {%v}", err)
 
 			// Getting other node for nodeSelector in engine
-			if testsDetails.NodeSelectorName, err = pkg.GetSelectorNode(&testsDetails, clients); err != nil || testsDetails.NodeSelectorName == "" {
-				log.Fatalf("Unable to get node name for node selector, due to %v", err)
-			}
+			testsDetails.NodeSelectorName, err = pkg.GetSelectorNode(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Error in getting node selector name, due to {%v}", err)
+			Expect(testsDetails.NodeSelectorName).NotTo(BeEmpty(), "Unable to get node name for node selector, due to {%v}", err)
 
 			//Cordon the application node
 			By("Cordoning Application Node")
-			if err := pkg.NodeCordon(&testsDetails); err != nil {
-				log.Fatalf("Failed NodeCordon, due to %v", err)
-			}
+			err = pkg.NodeCordon(&testsDetails)
+			Expect(err).To(BeNil(), "Fail to Cordon the app node, due to {%v}", err)
 
 			//Installing RBAC for the experiment
 			By("[Install]: Installing RBAC")
-			if err := pkg.InstallAnsibleRbac(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install rbac, due to %v", err)
-			}
+			err = pkg.InstallAnsibleRbac(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install rbac, due to {%v}", err)
 
 			//Installing Chaos Experiment for kubelet-service-kill
 			By("[Install]: Installing chaos experiment")
-			if err := pkg.InstallAnsibleChaosExperiment(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaos experiment, due to %v", err)
-			}
+			err = pkg.InstallAnsibleChaosExperiment(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos experiment, due to {%v}", err)
 
 			//Installing Chaos Engine for kubelet-service-kill
 			By("[Install]: Installing chaos engine")
-			if err := pkg.InstallAnsibleChaosEngine(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaosengine, due to %v", err)
-			}
+			err = pkg.InstallAnsibleChaosEngine(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos engine, due to {%v}", err)
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			if _, err := pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Runner pod status check failed, due to %v", err)
-			}
+			_, err = pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Waiting for experiment job to get completed
 			//And Print the logs of the job pod (chaos pod)
 			By("[Status]: Wait for job completion and then print logs")
-			if _, err := pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Fail to get the experiment job pod logs, due to %v", err)
-			}
+			_, err = pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Fail to get the experiment job pod logs, due to {%v}", err)
 
 			//Checking the chaosresult verdict
 			By("[Verdict]: Checking the chaosresult verdict")
-			if _, err := pkg.ChaosResultVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChasoResult Verdict check failed, due to %v", err)
-			}
+			_, err = pkg.ChaosResultVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
+
+		})
+	})
+	// BDD for uncordoning the application node
+	Context("Check for application node", func() {
+
+		It("Should uncordon the app node", func() {
+
+			testsDetails := types.TestDetails{}
+			clients := environment.ClientSets{}
+
+			//Getting kubeConfig and Generate ClientSets
+			By("[PreChaos]: Getting kubeconfig and generate clientset")
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig due to {%v}", err)
+
+			// Getting application node name
+			By("[Prepare]: Getting application node name")
+			_, err = pkg.GetApplicationNode(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Unable to get application node name due to {%v}", err)
 
 			//Uncordon the application node
 			By("Uncordoning Application Node")
-			if err := pkg.NodeUncordon(&testsDetails); err != nil {
-				log.Fatalf("Failed NodeUncordon, due to %v", err)
-			}
+			err = pkg.NodeUncordon(&testsDetails)
+			Expect(err).To(BeNil(), "Fail to uncordon the app node, due to {%v}", err)
 
 		})
 	})
@@ -120,9 +129,8 @@ var _ = Describe("BDD of kubelet-service-kill experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				log.Fatalf("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig due to {%v}", err)
 
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")
@@ -131,9 +139,8 @@ var _ = Describe("BDD of kubelet-service-kill experiment", func() {
 
 			//Checking chaosengine verdict
 			By("Checking the Verdict of Chaos Engine")
-			if _, err := pkg.ChaosEngineVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChaosEngine Verdict check failed, due to %v", err)
-			}
+			_, err = pkg.ChaosEngineVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
 
 		})
 	})

--- a/ansible/ansible-node-cpu-hog_test.go
+++ b/ansible/ansible-node-cpu-hog_test.go
@@ -1,7 +1,6 @@
 package ansible
 
 import (
-	"log"
 	"testing"
 
 	"github.com/litmuschaos/litmus-e2e/pkg"
@@ -29,11 +28,11 @@ var _ = Describe("BDD of node-cpu-hog experiment", func() {
 			testsDetails := types.TestDetails{}
 			clients := environment.ClientSets{}
 
+			var err error
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				klog.Infof("Unable to Get the kubeconfig due to %v", err)
-			}
+			err = clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig due to {%v}", err)
 
 			//Fetching all the default ENV
 			//Note: please don't provide custom experiment name here
@@ -43,46 +42,39 @@ var _ = Describe("BDD of node-cpu-hog experiment", func() {
 
 			// Checking the chaos operator running status
 			By("[Status]: Checking chaos operator status")
-			if err := pkg.OperatorStatusCheck(&testsDetails, clients); err != nil {
-				log.Fatalf("Operator status check failed, due to %v", err)
-			}
+			err = pkg.OperatorStatusCheck(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Operator status check failed, due to {%v}", err)
 
 			//Installing RBAC for the experiment
 			By("[Install]: Installing RBAC")
-			if err := pkg.InstallAnsibleRbac(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install rbac, due to %v", err)
-			}
+			err = pkg.InstallAnsibleRbac(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install rbac, due to {%v}", err)
 
 			//Installing Chaos Experiment for node-cpu-hog
 			By("[Install]: Installing chaos experiment")
-			if err := pkg.InstallAnsibleChaosExperiment(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaos experiment, due to %v", err)
-			}
+			err = pkg.InstallAnsibleChaosExperiment(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos experiment, due to {%v}", err)
 
 			//Installing Chaos Engine for node-cpu-hog
 			By("[Install]: Installing chaos engine")
-			if err := pkg.InstallAnsibleChaosEngine(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaosengine, due to %v", err)
-			}
+			err = pkg.InstallAnsibleChaosEngine(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos engine, due to {%v}", err)
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			if _, err := pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Runner pod status check failed, due to %v", err)
-			}
+			_, err = pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Waiting for experiment job to get completed
 			//And Print the logs of the job pod (chaos pod)
 			By("[Status]: Wait for job completion and then print logs")
-			if _, err := pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Fail to get the experiment job pod logs, due to %v", err)
-			}
+			_, err = pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Fail to get the experiment job pod logs, due to {%v}", err)
 
 			//Checking the chaosresult verdict
 			By("[Verdict]: Checking the chaosresult verdict")
-			if _, err := pkg.ChaosResultVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChasoResult Verdict check failed, due to %v", err)
-			}
+			_, err = pkg.ChaosResultVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 
 		})
 	})
@@ -96,9 +88,8 @@ var _ = Describe("BDD of node-cpu-hog experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				log.Fatalf("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig due to {%v}", err)
 
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")
@@ -107,9 +98,8 @@ var _ = Describe("BDD of node-cpu-hog experiment", func() {
 
 			//Checking chaosengine verdict
 			By("Checking the Verdict of Chaos Engine")
-			if _, err := pkg.ChaosEngineVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChaosEngine Verdict check failed, due to %v", err)
-			}
+			_, err = pkg.ChaosEngineVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
 
 		})
 	})

--- a/ansible/ansible-node-drain_test.go
+++ b/ansible/ansible-node-drain_test.go
@@ -1,7 +1,6 @@
 package ansible
 
 import (
-	"log"
 	"testing"
 
 	"github.com/litmuschaos/litmus-e2e/pkg"
@@ -30,11 +29,11 @@ var _ = Describe("BDD of node-drain experiment", func() {
 			testsDetails := types.TestDetails{}
 			clients := environment.ClientSets{}
 			var err error
+
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				klog.Infof("Unable to Get the kubeconfig due to %v", err)
-			}
+			err = clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig due to {%v}", err)
 
 			//Fetching all the default ENV
 			//Note: please don't provide custom experiment name here
@@ -44,69 +43,79 @@ var _ = Describe("BDD of node-drain experiment", func() {
 
 			// Checking the chaos operator running status
 			By("[Status]: Checking chaos operator status")
-			if err := pkg.OperatorStatusCheck(&testsDetails, clients); err != nil {
-				log.Fatalf("Operator status check failed, due to %v", err)
-			}
+			err = pkg.OperatorStatusCheck(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Operator status check failed, due to {%v}", err)
 
 			// Getting application node name
 			By("[Prepare]: Getting application node name")
-			if _, err := pkg.GetApplicationNode(&testsDetails, clients); err != nil {
-				log.Fatalf("Unable to get application node name, due to %v", err)
-			}
+			_, err = pkg.GetApplicationNode(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Unable to get application node name due to {%v}", err)
 
 			// Getting other node for nodeSelector in engine
-			if testsDetails.NodeSelectorName, err = pkg.GetSelectorNode(&testsDetails, clients); err != nil || testsDetails.NodeSelectorName == "" {
-				log.Fatalf("Unable to get node name for node selector, due to %v", err)
-			}
+			testsDetails.NodeSelectorName, err = pkg.GetSelectorNode(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Error in getting node selector name, due to {%v}", err)
+			Expect(testsDetails.NodeSelectorName).NotTo(BeEmpty(), "Unable to get node name for node selector, due to {%v}", err)
 
 			//Cordon the application node
 			By("Cordoning Application Node")
-			if err := pkg.NodeCordon(&testsDetails); err != nil {
-				log.Fatalf("Failed NodeCordon, due to %v", err)
-			}
+			err = pkg.NodeCordon(&testsDetails)
+			Expect(err).To(BeNil(), "Fail to Cordon the app node, due to {%v}", err)
 
 			//Installing RBAC for the experiment
 			By("[Install]: Installing RBAC")
-			if err := pkg.InstallAnsibleRbac(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install rbac, due to %v", err)
-			}
+			err = pkg.InstallAnsibleRbac(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install rbac, due to {%v}", err)
 
-			//Installing Chaos Experiment for node-cordon
+			//Installing Chaos Experiment for node-drain
 			By("[Install]: Installing chaos experiment")
-			if err := pkg.InstallAnsibleChaosExperiment(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaos experiment, due to %v", err)
-			}
+			err = pkg.InstallAnsibleChaosExperiment(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos experiment, due to {%v}", err)
 
-			//Installing Chaos Engine for node-cordon
+			//Installing Chaos Engine for node-drain
 			By("[Install]: Installing chaos engine")
-			if err := pkg.InstallAnsibleChaosEngine(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaosengine, due to %v", err)
-			}
+			err = pkg.InstallAnsibleChaosEngine(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos engine, due to {%v}", err)
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			if _, err := pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Runner pod status check failed, due to %v", err)
-			}
+			_, err = pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Waiting for experiment job to get completed
 			//And Print the logs of the job pod (chaos pod)
 			By("[Status]: Wait for job completion and then print logs")
-			if _, err := pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Fail to get the experiment job pod logs, due to %v", err)
-			}
+			_, err = pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Fail to get the experiment job pod logs, due to {%v}", err)
 
 			//Checking the chaosresult verdict
 			By("[Verdict]: Checking the chaosresult verdict")
-			if _, err := pkg.ChaosResultVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChasoResult Verdict check failed, due to %v", err)
-			}
+			_, err = pkg.ChaosResultVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
+
+		})
+	})
+	// BDD for uncordoning the application node
+	Context("Check for application node", func() {
+
+		It("Should uncordon the app node", func() {
+
+			testsDetails := types.TestDetails{}
+			clients := environment.ClientSets{}
+
+			//Getting kubeConfig and Generate ClientSets
+			By("[PreChaos]: Getting kubeconfig and generate clientset")
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig due to {%v}", err)
+
+			// Getting application node name
+			By("[Prepare]: Getting application node name")
+			_, err = pkg.GetApplicationNode(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Unable to get application node name due to {%v}", err)
 
 			//Uncordon the application node
 			By("Uncordoning Application Node")
-			if err := pkg.NodeUncordon(&testsDetails); err != nil {
-				log.Fatalf("Failed NodeUncordon, due to %v", err)
-			}
+			err = pkg.NodeUncordon(&testsDetails)
+			Expect(err).To(BeNil(), "Fail to uncordon the app node, due to {%v}", err)
 
 		})
 	})
@@ -120,9 +129,8 @@ var _ = Describe("BDD of node-drain experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				log.Fatalf("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig due to {%v}", err)
 
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")
@@ -131,9 +139,8 @@ var _ = Describe("BDD of node-drain experiment", func() {
 
 			//Checking chaosengine verdict
 			By("Checking the Verdict of Chaos Engine")
-			if _, err := pkg.ChaosEngineVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChaosEngine Verdict check failed, due to %v", err)
-			}
+			_, err = pkg.ChaosEngineVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
 
 		})
 	})

--- a/ansible/ansible-node-memory-hog_test.go
+++ b/ansible/ansible-node-memory-hog_test.go
@@ -1,7 +1,6 @@
 package ansible
 
 import (
-	"log"
 	"testing"
 
 	"github.com/litmuschaos/litmus-e2e/pkg"
@@ -31,9 +30,8 @@ var _ = Describe("BDD of node-memory-hog experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				klog.Infof("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig due to {%v}", err)
 
 			//Fetching all the default ENV
 			//Note: please don't provide custom experiment name here
@@ -43,46 +41,39 @@ var _ = Describe("BDD of node-memory-hog experiment", func() {
 
 			// Checking the chaos operator running status
 			By("[Status]: Checking chaos operator status")
-			if err := pkg.OperatorStatusCheck(&testsDetails, clients); err != nil {
-				log.Fatalf("Operator status check failed, due to %v", err)
-			}
+			err = pkg.OperatorStatusCheck(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Operator status check failed, due to {%v}", err)
 
 			//Installing RBAC for the experiment
 			By("[Install]: Installing RBAC")
-			if err := pkg.InstallAnsibleRbac(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install rbac, due to %v", err)
-			}
+			err = pkg.InstallAnsibleRbac(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install rbac, due to {%v}", err)
 
 			//Installing Chaos Experiment for node-memory-hog
 			By("[Install]: Installing chaos experiment")
-			if err := pkg.InstallAnsibleChaosExperiment(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaos experiment, due to %v", err)
-			}
+			err = pkg.InstallAnsibleChaosExperiment(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos experiment, due to {%v}", err)
 
 			//Installing Chaos Engine for node-memory-hog
 			By("[Install]: Installing chaos engine")
-			if err := pkg.InstallAnsibleChaosEngine(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaosengine, due to %v", err)
-			}
+			err = pkg.InstallAnsibleChaosEngine(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos engine, due to {%v}", err)
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			if _, err := pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Runner pod status check failed, due to %v", err)
-			}
+			_, err = pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Waiting for experiment job to get completed
 			//And Print the logs of the job pod (chaos pod)
 			By("[Status]: Wait for job completion and then print logs")
-			if _, err := pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Fail to get the experiment job pod logs, due to %v", err)
-			}
+			_, err = pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Fail to get the experiment job pod logs, due to {%v}", err)
 
 			//Checking the chaosresult verdict
 			By("[Verdict]: Checking the chaosresult verdict")
-			if _, err := pkg.ChaosResultVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChasoResult Verdict check failed, due to %v", err)
-			}
+			_, err = pkg.ChaosResultVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 
 		})
 	})
@@ -96,9 +87,8 @@ var _ = Describe("BDD of node-memory-hog experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				log.Fatalf("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig due to {%v}", err)
 
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")
@@ -107,9 +97,8 @@ var _ = Describe("BDD of node-memory-hog experiment", func() {
 
 			//Checking chaosengine verdict
 			By("Checking the Verdict of Chaos Engine")
-			if _, err := pkg.ChaosEngineVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChaosEngine Verdict check failed, due to %v", err)
-			}
+			_, err = pkg.ChaosEngineVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
 
 		})
 	})

--- a/ansible/ansible-pod-cpu-hog_test.go
+++ b/ansible/ansible-pod-cpu-hog_test.go
@@ -1,7 +1,6 @@
 package ansible
 
 import (
-	"log"
 	"testing"
 
 	"github.com/litmuschaos/litmus-e2e/pkg"
@@ -31,9 +30,8 @@ var _ = Describe("BDD of pod-cpu-hog experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				klog.Infof("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig due to {%v}", err)
 
 			//Fetching all the default ENV
 			//Note: please don't provide custom experiment name here
@@ -43,46 +41,39 @@ var _ = Describe("BDD of pod-cpu-hog experiment", func() {
 
 			// Checking the chaos operator running status
 			By("[Status]: Checking chaos operator status")
-			if err := pkg.OperatorStatusCheck(&testsDetails, clients); err != nil {
-				log.Fatalf("Operator status check failed, due to %v", err)
-			}
+			err = pkg.OperatorStatusCheck(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Operator status check failed, due to {%v}", err)
 
 			//Installing RBAC for the experiment
 			By("[Install]: Installing RBAC")
-			if err := pkg.InstallAnsibleRbac(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install rbac, due to %v", err)
-			}
+			err = pkg.InstallAnsibleRbac(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install rbac, due to {%v}", err)
 
-			//Installing Chaos Experiment for pod-cpu-hog
+			//Installing Chaos Experiment for container-kill
 			By("[Install]: Installing chaos experiment")
-			if err := pkg.InstallAnsibleChaosExperiment(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaos experiment, due to %v", err)
-			}
+			err = pkg.InstallAnsibleChaosExperiment(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos experiment, due to {%v}", err)
 
-			//Installing Chaos Engine for pod-cpu-hog
+			//Installing Chaos Engine for container-kill
 			By("[Install]: Installing chaos engine")
-			if err := pkg.InstallAnsibleChaosEngine(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaosengine, due to %v", err)
-			}
+			err = pkg.InstallAnsibleChaosEngine(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos engine, due to {%v}", err)
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			if _, err := pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Runner pod status check failed, due to %v", err)
-			}
+			_, err = pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Waiting for experiment job to get completed
 			//And Print the logs of the job pod (chaos pod)
 			By("[Status]: Wait for job completion and then print logs")
-			if _, err := pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Fail to get the experiment job pod logs, due to %v", err)
-			}
+			_, err = pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Fail to get the experiment job pod logs, due to {%v}", err)
 
 			//Checking the chaosresult verdict
 			By("[Verdict]: Checking the chaosresult verdict")
-			if _, err := pkg.ChaosResultVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChasoResult Verdict check failed, due to %v", err)
-			}
+			_, err = pkg.ChaosResultVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 
 		})
 	})
@@ -96,9 +87,8 @@ var _ = Describe("BDD of pod-cpu-hog experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				log.Fatalf("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig due to {%v}", err)
 
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")
@@ -107,10 +97,8 @@ var _ = Describe("BDD of pod-cpu-hog experiment", func() {
 
 			//Checking chaosengine verdict
 			By("Checking the Verdict of Chaos Engine")
-			if _, err := pkg.ChaosEngineVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChaosEngine Verdict check failed, due to %v", err)
-			}
-
+			_, err = pkg.ChaosEngineVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
 		})
 	})
 })

--- a/ansible/ansible-pod-delete_test.go
+++ b/ansible/ansible-pod-delete_test.go
@@ -1,7 +1,6 @@
 package ansible
 
 import (
-	"log"
 	"testing"
 
 	"github.com/litmuschaos/litmus-e2e/pkg"
@@ -31,9 +30,8 @@ var _ = Describe("BDD of pod-delete experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				klog.Infof("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig due to {%v}", err)
 
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")
@@ -42,46 +40,39 @@ var _ = Describe("BDD of pod-delete experiment", func() {
 
 			// Checking the chaos operator running status
 			By("[Status]: Checking chaos operator status")
-			if err := pkg.OperatorStatusCheck(&testsDetails, clients); err != nil {
-				log.Fatalf("Operator status check failed, due to %v", err)
-			}
+			err = pkg.OperatorStatusCheck(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Operator status check failed, due to {%v}", err)
 
 			//Installing RBAC for the experiment
 			By("[Install]: Installing RBAC")
-			if err := pkg.InstallAnsibleRbac(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install rbac, due to %v", err)
-			}
+			err = pkg.InstallAnsibleRbac(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install rbac, due to {%v}", err)
 
 			//Installing Chaos Experiment for pod-delete
 			By("[Install]: Installing chaos experiment")
-			if err := pkg.InstallAnsibleChaosExperiment(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaos experiment, due to %v", err)
-			}
+			err = pkg.InstallAnsibleChaosExperiment(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos experiment, due to {%v}", err)
 
 			//Installing Chaos Engine for pod-delete
 			By("[Install]: Installing chaos engine")
-			if err := pkg.InstallAnsibleChaosEngine(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaos engine, due to %v", err)
-			}
+			err = pkg.InstallAnsibleChaosEngine(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos engine, due to {%v}", err)
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			if _, err := pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Runner pod status check failed, due to %v", err)
-			}
+			_, err = pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Waiting for experiment job to get completed
 			//And Print the logs of the job pod (chaos pod)
 			By("[Status]: Wait for job completion and then print logs")
-			if _, err := pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Fail to get the experiment job pod logs, due to %v", err)
-			}
+			_, err = pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Fail to get the experiment job pod logs, due to {%v}", err)
 
 			//Checking the chaosresult verdict
 			By("[Verdict]: Checking the chaosresult verdict")
-			if _, err := pkg.ChaosResultVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChasoResult Verdict check failed, due to %v", err)
-			}
+			_, err = pkg.ChaosResultVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 
 		})
 	})
@@ -95,10 +86,8 @@ var _ = Describe("BDD of pod-delete experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				log.Fatalf("Unable to Get the kubeconfig due to %v", err)
-			}
-
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig due to {%v}", err)
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")
 			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
@@ -106,10 +95,8 @@ var _ = Describe("BDD of pod-delete experiment", func() {
 
 			//Checking chaosengine verdict
 			By("Checking the Verdict of Chaos Engine")
-			if _, err := pkg.ChaosEngineVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChaosEngine Verdict check failed, due to %v", err)
-			}
-
+			_, err = pkg.ChaosEngineVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
 		})
 	})
 })

--- a/ansible/ansible-pod-memory-hog_test.go
+++ b/ansible/ansible-pod-memory-hog_test.go
@@ -1,7 +1,6 @@
 package ansible
 
 import (
-	"log"
 	"testing"
 
 	"github.com/litmuschaos/litmus-e2e/pkg"
@@ -29,11 +28,11 @@ var _ = Describe("BDD of pod-memory-hog experiment", func() {
 			testsDetails := types.TestDetails{}
 			clients := environment.ClientSets{}
 
+			var err error
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				klog.Infof("Unable to Get the kubeconfig due to %v", err)
-			}
+			err = clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig due to {%v}", err)
 
 			//Fetching all the default ENV
 			//Note: please don't provide custom experiment name here
@@ -43,46 +42,39 @@ var _ = Describe("BDD of pod-memory-hog experiment", func() {
 
 			// Checking the chaos operator running status
 			By("[Status]: Checking chaos operator status")
-			if err := pkg.OperatorStatusCheck(&testsDetails, clients); err != nil {
-				log.Fatalf("Operator status check failed, due to %v", err)
-			}
+			err = pkg.OperatorStatusCheck(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Operator status check failed, due to {%v}", err)
 
 			//Installing RBAC for the experiment
 			By("[Install]: Installing RBAC")
-			if err := pkg.InstallAnsibleRbac(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install rbac, due to %v", err)
-			}
+			err = pkg.InstallAnsibleRbac(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install rbac, due to {%v}", err)
 
 			//Installing Chaos Experiment for pod-memory-hog
 			By("[Install]: Installing chaos experiment")
-			if err := pkg.InstallAnsibleChaosExperiment(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaos experiment, due to %v", err)
-			}
+			err = pkg.InstallAnsibleChaosExperiment(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos experiment, due to {%v}", err)
 
 			//Installing Chaos Engine for pod-memory-hog
 			By("[Install]: Installing chaos engine")
-			if err := pkg.InstallAnsibleChaosEngine(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaosengine, due to %v", err)
-			}
+			err = pkg.InstallAnsibleChaosEngine(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos engine, due to {%v}", err)
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			if _, err := pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Runner pod status check failed, due to %v", err)
-			}
+			_, err = pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Waiting for experiment job to get completed
 			//And Print the logs of the job pod (chaos pod)
 			By("[Status]: Wait for job completion and then print logs")
-			if _, err := pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Fail to get the experiment job pod logs, due to %v", err)
-			}
+			_, err = pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Fail to get the experiment job pod logs, due to {%v}", err)
 
 			//Checking the chaosresult verdict
 			By("[Verdict]: Checking the chaosresult verdict")
-			if _, err := pkg.ChaosResultVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChasoResult Verdict check failed, due to %v", err)
-			}
+			_, err = pkg.ChaosResultVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 
 		})
 	})
@@ -96,9 +88,8 @@ var _ = Describe("BDD of pod-memory-hog experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				log.Fatalf("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig due to {%v}", err)
 
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")
@@ -107,10 +98,8 @@ var _ = Describe("BDD of pod-memory-hog experiment", func() {
 
 			//Checking chaosengine verdict
 			By("Checking the Verdict of Chaos Engine")
-			if _, err := pkg.ChaosEngineVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChaosEngine Verdict check failed, due to %v", err)
-			}
-
+			_, err = pkg.ChaosEngineVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
 		})
 	})
 })

--- a/ansible/ansible-pod-network-corruption_test.go
+++ b/ansible/ansible-pod-network-corruption_test.go
@@ -1,7 +1,6 @@
 package ansible
 
 import (
-	"log"
 	"testing"
 
 	"github.com/litmuschaos/litmus-e2e/pkg"
@@ -31,9 +30,8 @@ var _ = Describe("BDD of pod-network-corruption experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				klog.Infof("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig due to {%v}", err)
 
 			//Fetching all the default ENV
 			//Note: please don't provide custom experiment name here
@@ -43,46 +41,39 @@ var _ = Describe("BDD of pod-network-corruption experiment", func() {
 
 			// Checking the chaos operator running status
 			By("[Status]: Checking chaos operator status")
-			if err := pkg.OperatorStatusCheck(&testsDetails, clients); err != nil {
-				log.Fatalf("Operator status check failed, due to %v", err)
-			}
+			err = pkg.OperatorStatusCheck(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Operator status check failed, due to {%v}", err)
 
 			//Installing RBAC for the experiment
 			By("[Install]: Installing RBAC")
-			if err := pkg.InstallAnsibleRbac(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install rbac, due to %v", err)
-			}
+			err = pkg.InstallAnsibleRbac(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install rbac, due to {%v}", err)
 
 			//Installing Chaos Experiment for pod-network-corruption
 			By("[Install]: Installing chaos experiment")
-			if err := pkg.InstallAnsibleChaosExperiment(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaos experiment, due to %v", err)
-			}
+			err = pkg.InstallAnsibleChaosExperiment(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos experiment, due to {%v}", err)
 
 			//Installing Chaos Engine for pod-network-corruption
 			By("[Install]: Installing chaos engine")
-			if err := pkg.InstallAnsibleChaosEngine(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaosengine, due to %v", err)
-			}
+			err = pkg.InstallAnsibleChaosEngine(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos engine, due to {%v}", err)
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			if _, err := pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Runner pod status check failed, due to %v", err)
-			}
+			_, err = pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Waiting for experiment job to get completed
 			//And Print the logs of the job pod (chaos pod)
 			By("[Status]: Wait for job completion and then print logs")
-			if _, err := pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Fail to get the experiment job pod logs, due to %v", err)
-			}
+			_, err = pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Fail to get the experiment job pod logs, due to {%v}", err)
 
 			//Checking the chaosresult verdict
 			By("[Verdict]: Checking the chaosresult verdict")
-			if _, err := pkg.ChaosResultVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChasoResult Verdict check failed, due to %v", err)
-			}
+			_, err = pkg.ChaosResultVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 
 		})
 	})
@@ -96,9 +87,8 @@ var _ = Describe("BDD of pod-network-corruption experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				log.Fatalf("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig due to {%v}", err)
 
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")
@@ -107,9 +97,8 @@ var _ = Describe("BDD of pod-network-corruption experiment", func() {
 
 			//Checking chaosengine verdict
 			By("Checking the Verdict of Chaos Engine")
-			if _, err := pkg.ChaosEngineVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChaosEngine Verdict check failed, due to %v", err)
-			}
+			_, err = pkg.ChaosEngineVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
 
 		})
 	})

--- a/ansible/ansible-pod-network-latency_test.go
+++ b/ansible/ansible-pod-network-latency_test.go
@@ -1,7 +1,6 @@
 package ansible
 
 import (
-	"log"
 	"testing"
 
 	"github.com/litmuschaos/litmus-e2e/pkg"
@@ -31,9 +30,8 @@ var _ = Describe("BDD of pod-network-latency experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				klog.Infof("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig due to {%v}", err)
 
 			//Fetching all the default ENV
 			//Note: please don't provide custom experiment name here
@@ -43,46 +41,39 @@ var _ = Describe("BDD of pod-network-latency experiment", func() {
 
 			// Checking the chaos operator running status
 			By("[Status]: Checking chaos operator status")
-			if err := pkg.OperatorStatusCheck(&testsDetails, clients); err != nil {
-				log.Fatalf("Operator status check failed, due to %v", err)
-			}
+			err = pkg.OperatorStatusCheck(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Operator status check failed, due to {%v}", err)
 
 			//Installing RBAC for the experiment
 			By("[Install]: Installing RBAC")
-			if err := pkg.InstallAnsibleRbac(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install rbac, due to %v", err)
-			}
+			err = pkg.InstallAnsibleRbac(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install rbac, due to {%v}", err)
 
 			//Installing Chaos Experiment for pod-network-latency
 			By("[Install]: Installing chaos experiment")
-			if err := pkg.InstallAnsibleChaosExperiment(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaos experiment, due to %v", err)
-			}
+			err = pkg.InstallAnsibleChaosExperiment(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos experiment, due to {%v}", err)
 
 			//Installing Chaos Engine for pod-network-latency
 			By("[Install]: Installing chaos engine")
-			if err := pkg.InstallAnsibleChaosEngine(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaosengine, due to %v", err)
-			}
+			err = pkg.InstallAnsibleChaosEngine(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos engine, due to {%v}", err)
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			if _, err := pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Runner pod status check failed, due to %v", err)
-			}
+			_, err = pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Waiting for experiment job to get completed
 			//And Print the logs of the job pod (chaos pod)
 			By("[Status]: Wait for job completion and then print logs")
-			if _, err := pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Fail to get the experiment job pod logs, due to %v", err)
-			}
+			_, err = pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Fail to get the experiment job pod logs, due to {%v}", err)
 
 			//Checking the chaosresult verdict
 			By("[Verdict]: Checking the chaosresult verdict")
-			if _, err := pkg.ChaosResultVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChasoResult Verdict check failed, due to %v", err)
-			}
+			_, err = pkg.ChaosResultVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 
 		})
 	})
@@ -96,9 +87,8 @@ var _ = Describe("BDD of pod-network-latency experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				log.Fatalf("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig due to {%v}", err)
 
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")
@@ -107,9 +97,8 @@ var _ = Describe("BDD of pod-network-latency experiment", func() {
 
 			//Checking chaosengine verdict
 			By("Checking the Verdict of Chaos Engine")
-			if _, err := pkg.ChaosEngineVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChaosEngine Verdict check failed, due to %v", err)
-			}
+			_, err = pkg.ChaosEngineVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
 
 		})
 	})

--- a/ansible/ansible-pod-network-loss_test.go
+++ b/ansible/ansible-pod-network-loss_test.go
@@ -1,7 +1,6 @@
 package ansible
 
 import (
-	"log"
 	"testing"
 
 	"github.com/litmuschaos/litmus-e2e/pkg"
@@ -31,9 +30,8 @@ var _ = Describe("BDD of pod-network-loss experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				klog.Infof("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig due to {%v}", err)
 
 			//Fetching all the default ENV
 			//Note: please don't provide custom experiment name here
@@ -43,46 +41,39 @@ var _ = Describe("BDD of pod-network-loss experiment", func() {
 
 			// Checking the chaos operator running status
 			By("[Status]: Checking chaos operator status")
-			if err := pkg.OperatorStatusCheck(&testsDetails, clients); err != nil {
-				log.Fatalf("Operator status check failed, due to %v", err)
-			}
+			err = pkg.OperatorStatusCheck(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Operator status check failed, due to {%v}", err)
 
 			//Installing RBAC for the experiment
 			By("[Install]: Installing RBAC")
-			if err := pkg.InstallAnsibleRbac(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install rbac, due to %v", err)
-			}
+			err = pkg.InstallAnsibleRbac(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install rbac, due to {%v}", err)
 
 			//Installing Chaos Experiment for pod-network-loss
 			By("[Install]: Installing chaos experiment")
-			if err := pkg.InstallAnsibleChaosExperiment(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaos experiment, due to %v", err)
-			}
+			err = pkg.InstallAnsibleChaosExperiment(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos experiment, due to {%v}", err)
 
 			//Installing Chaos Engine for pod-network-loss
 			By("[Install]: Installing chaos engine")
-			if err := pkg.InstallAnsibleChaosEngine(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaosengine, due to %v", err)
-			}
+			err = pkg.InstallAnsibleChaosEngine(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos engine, due to {%v}", err)
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			if _, err := pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Runner pod status check failed, due to %v", err)
-			}
+			_, err = pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Waiting for experiment job to get completed
 			//And Print the logs of the job pod (chaos pod)
 			By("[Status]: Wait for job completion and then print logs")
-			if _, err := pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Fail to get the experiment job pod logs, due to %v", err)
-			}
+			_, err = pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Fail to get the experiment job pod logs, due to {%v}", err)
 
 			//Checking the chaosresult verdict
 			By("[Verdict]: Checking the chaosresult verdict")
-			if _, err := pkg.ChaosResultVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChasoResult Verdict check failed, due to %v", err)
-			}
+			_, err = pkg.ChaosResultVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 
 		})
 	})
@@ -96,9 +87,8 @@ var _ = Describe("BDD of pod-network-loss experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				log.Fatalf("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig due to {%v}", err)
 
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")
@@ -107,9 +97,8 @@ var _ = Describe("BDD of pod-network-loss experiment", func() {
 
 			//Checking chaosengine verdict
 			By("Checking the Verdict of Chaos Engine")
-			if _, err := pkg.ChaosEngineVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChaosEngine Verdict check failed, due to %v", err)
-			}
+			_, err = pkg.ChaosEngineVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
 
 		})
 	})

--- a/go.mod
+++ b/go.mod
@@ -21,12 +21,9 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073 // indirect
-	golang.org/x/tools v0.0.0-20200311090712-aafaee8bce8c // indirect
 	k8s.io/api v0.0.0-20190918195907-bd6ac527cfd2
 	k8s.io/apimachinery v0.0.0-20190817020851-f2f3a405f61d
 	k8s.io/client-go v0.0.0-20190918200256-06eb1244587a
-	k8s.io/code-generator v0.15.12-beta.0 // indirect
-	k8s.io/gengo v0.0.0-20200205140755-e0e292d8aa12 // indirect
 	k8s.io/klog v1.0.0
 	k8s.io/utils v0.0.0-20200229041039-0a110f9eb7ab // indirect
 	sigs.k8s.io/controller-runtime v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,7 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/evanphx/json-patch v0.0.0-20190203023257-5858425f7550/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/fsnotify/fsnotify v1.4.8 h1:vmjGRBE6skJRlqYIcSsh9B823pS/MqsvxevqbMnBPbI=
 github.com/fsnotify/fsnotify v1.4.8/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/ghodss/yaml v0.0.0-20180820084758-c7ce16629ff4/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
@@ -186,9 +187,11 @@ github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQL
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/litmuschaos/chaos-operator v0.0.0-20200310090048-610d15206c2f h1:UbBsrN7C24lawOSCLasqAoJOUTvtfGaOTKJlpv1I+tI=
 github.com/litmuschaos/chaos-operator v0.0.0-20200310090048-610d15206c2f/go.mod h1:WWk1paEawYmDV2L+59r5s6N8DDMpyeIuAxero3+PQOA=
@@ -415,7 +418,6 @@ golang.org/x/tools v0.0.0-20200207183749-b753a1ba74fa/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20200212150539-ea181f53ac56/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200224181240-023911ca70b2/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200304193943-95d2e580d8eb/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
-golang.org/x/tools v0.0.0-20200311090712-aafaee8bce8c/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
@@ -469,6 +471,7 @@ google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8
 google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
@@ -502,16 +505,13 @@ k8s.io/apiserver v0.0.0-20190918200908-1e17798da8c1/go.mod h1:4FuDU+iKPjdsdQSN3G
 k8s.io/client-go v0.0.0-20190918200256-06eb1244587a h1:huOvPq1vO7dkuw9rZPYsLGpFmyGvy6L8q6mDItgkdQ4=
 k8s.io/client-go v0.0.0-20190918200256-06eb1244587a/go.mod h1:3YAcTbI2ArBRmhHns5vlHRX8YQqvkVYpz+U/N5i1mVU=
 k8s.io/code-generator v0.0.0-20190612205613-18da4a14b22b/go.mod h1:G8bQwmHm2eafm5bgtX67XDZQ8CWKSGu9DekI+yN4Y5I=
-k8s.io/code-generator v0.15.12-beta.0/go.mod h1:G8bQwmHm2eafm5bgtX67XDZQ8CWKSGu9DekI+yN4Y5I=
 k8s.io/component-base v0.0.0-20190918200425-ed2f0867c778/go.mod h1:DFWQCXgXVLiWtzFaS17KxHdlUeUymP7FLxZSkmL9/jU=
 k8s.io/gengo v0.0.0-20190116091435-f8a0810f38af/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
-k8s.io/gengo v0.0.0-20200205140755-e0e292d8aa12/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.1/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.3/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
-k8s.io/kube-openapi v0.0.0-20180711000925-0cf8f7e6ed1d/go.mod h1:BXM9ceUBTj2QnfH2MK1odQs778ajze1RxcmP6S8RVVc=
 k8s.io/kube-openapi v0.0.0-20190228160746-b3a7cee44a30 h1:TRb4wNWoBVrH9plmkp2q86FIDppkbrEXdXlxU3a3BMI=
 k8s.io/kube-openapi v0.0.0-20190228160746-b3a7cee44a30/go.mod h1:BXM9ceUBTj2QnfH2MK1odQs778ajze1RxcmP6S8RVVc=
 k8s.io/utils v0.0.0-20190221042446-c2654d5206da/go.mod h1:8k8uAuAQ0rXslZKaEWd0c3oVhZz7sSzSiPnVZayjIX0=

--- a/operator/admin-mode_test.go
+++ b/operator/admin-mode_test.go
@@ -34,9 +34,8 @@ var _ = Describe("BDD of operator reconcile resiliency check", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				klog.Infof("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig due to {%v}", err)
 
 			//Fetching all the default ENV
 			//Note: please don't provide custom experiment name here
@@ -46,59 +45,53 @@ var _ = Describe("BDD of operator reconcile resiliency check", func() {
 
 			// Checking the chaos operator running status
 			By("[Status]: Checking chaos operator status")
-			if err := pkg.OperatorStatusCheck(&testsDetails, clients); err != nil {
-				log.Fatalf("Operator status check failed, due to %v", err)
-			}
+			err = pkg.OperatorStatusCheck(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Operator status check failed, due to {%v}", err)
 
 			//Creating application for pod-delete in default namespace
 			By("Creating deployment for pod-delete chaos")
-			if err := pkg.CreateDeployment(clients, "adminapp", "nginx:1.12", "default"); err != nil {
-				log.Fatalf("Operator status check failed, due to %v", err)
-			}
+			err = pkg.CreateDeployment(clients, "adminapp", "nginx:1.12", "default")
+			Expect(err).To(BeNil(), "Deployment adminapp failed to create, due to {%v}", err)
 
 			//Waiting for deployment to get ready
-			if err := pkg.DeploymentStatusCheck(&testsDetails, "adminapp", "default", clients); err != nil {
-				log.Fatalf("Error Timeout, %v", err)
-			}
+			err = pkg.DeploymentStatusCheck(&testsDetails, "adminapp", "default", clients)
+			Expect(err).To(BeNil(), "Error Timeout, {%v}", err)
+
 			testsDetails.AppNS = "default"
 			testsDetails.AppLabel = "run=adminapp"
+
 			//Installing admin RBAC for the chaos
 			By("[Install]: Installing RBAC for pod-delete")
-			if err := pkg.InstallAdminRbac(&testsDetails); err != nil {
-				log.Fatalf("Fail to install rbac, due to %v", err)
-			}
+			err = pkg.InstallAdminRbac(&testsDetails)
+			Expect(err).To(BeNil(), "Fail to install rbac, due to {%v}", err)
 
 			//Installing Chaos Experiment for pod-delete
 			By("[Install]: Installing pod-delete chaos experiment")
-			if err := pkg.InstallGoChaosExperiment(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaos experiment, due to %v", err)
-			}
+			err = pkg.InstallGoChaosExperiment(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos experiment, due to {%v}", err)
 
 			//Installing Chaos Engine for container-kill
 			By("[Install]: Installing chaos engine")
-			if err := pkg.InstallGoChaosEngine(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaosengine, due to %v", err)
-			}
+			err = pkg.InstallGoChaosEngine(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaosengine, due to {%v}", err)
 
 			//Checking runner pod running state
 			testsDetails.AppNS = "litmus"
 			By("[Status]: Runner pod running status check")
-			if _, err := pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Runner pod status check failed, due to %v", err)
-			}
+			_, err = pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Waiting for experiment job to get completed
 			//And Print the logs of the job pod (chaos pod)
 			By("[Status]: Wait for job completion and then print logs")
-			if _, err := pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Fail to get the expweriment job pod logs, due to %v", err)
-			}
+			_, err = pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Fail to get the experiment job pod logs, due to {%v}", err)
 
 			//Checking the chaosresult verdict
 			By("[Verdict]: Checking the chaosresult verdict")
-			if _, err := pkg.ChaosResultVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChasoResult Verdict check failed, due to %v", err)
-			}
+			_, err = pkg.ChaosResultVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
+
 		})
 	})
 	// BDD TEST CASE 2
@@ -112,9 +105,8 @@ var _ = Describe("BDD of operator reconcile resiliency check", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				klog.Infof("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig due to {%v}", err)
 
 			//Fetching all the default ENV
 			//Note: please don't provide custom experiment name here
@@ -124,49 +116,44 @@ var _ = Describe("BDD of operator reconcile resiliency check", func() {
 
 			//Create Namespace for the test
 			By("Creating namespace")
-			if _, err := pkg.CreateNamespace(clients, "test"); err != nil {
-				log.Fatalf("Namespace creation failed, due to %v", err)
-			}
+			_, err = pkg.CreateNamespace(clients, "test")
+			Expect(err).To(BeNil(), "Namespace creation failed, due to {%v}", err)
+
 			testsDetails.ChaosNamespace = "test"
 			testsDetails.AppNS = "default"
 			testsDetails.AppLabel = "run=adminapp"
 			//Installing admin RBAC for the chaos
 			By("[Install]: Installing RBAC")
-			if err := pkg.InstallAdminRbac(&testsDetails); err != nil {
-				log.Fatalf("Fail to install rbac, due to %v", err)
-			}
+			err = pkg.InstallAdminRbac(&testsDetails)
+			Expect(err).To(BeNil(), "Fail to create namespace, due to {%v}", err)
 
 			//Installing Chaos Experiment for pod-delete
 			By("[Install]: Installing pod-delete chaos experiment")
-			if err := pkg.InstallGoChaosExperiment(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaos experiment, due to %v", err)
-			}
+			err = pkg.InstallGoChaosExperiment(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos experiment, due to {%v}", err)
 
 			//Installing Chaos Engine for container-kill
 			By("[Install]: Installing chaos engine")
-			if err := pkg.InstallGoChaosEngine(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaosengine, due to %v", err)
-			}
+			err = pkg.InstallGoChaosEngine(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos experiment, due to {%v}", err)
 
 			//Checking runner pod running state
 			testsDetails.AppNS = "test"
 			By("[Status]: Runner pod running status check")
-			if _, err := pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Runner pod status check failed, due to %v", err)
-			}
+			_, err = pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients)
+			log.Fatalf("Fail to install chaosengine, due to %v", err)
+			Expect(err).To(BeNil(), "Unable to check the runner pod status, due to {%v}", err)
 
 			//Waiting for experiment job to get completed
 			//And Print the logs of the job pod (chaos pod)
 			By("[Status]: Wait for job completion and then print logs")
-			if _, err := pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Fail to get the expweriment job pod logs, due to %v", err)
-			}
+			_, err = pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Fail to get the experiment job pod logs, due to {%v}", err)
 
 			//Checking the chaosresult verdict
 			By("[Verdict]: Checking the chaosresult verdict")
-			if _, err := pkg.ChaosResultVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChasoResult Verdict check failed, due to %v", err)
-			}
+			_, err = pkg.ChaosResultVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 		})
 	})
 

--- a/operator/reconcile-resiliency_test.go
+++ b/operator/reconcile-resiliency_test.go
@@ -35,9 +35,8 @@ var _ = Describe("BDD of operator reconcile resiliency check", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				klog.Infof("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig due to {%v}", err)
 
 			//Fetching all the default ENV
 			//Note: please don't provide custom experiment name here
@@ -47,31 +46,26 @@ var _ = Describe("BDD of operator reconcile resiliency check", func() {
 
 			// Checking the chaos operator running status
 			By("[Status]: Checking chaos operator status")
-			if err := pkg.OperatorStatusCheck(&testsDetails, clients); err != nil {
-				log.Fatalf("Operator status check failed, due to %v", err)
-			}
+			err = pkg.OperatorStatusCheck(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Operator status check failed, due to {%v}", err)
 
 			//Creating first application for pod-delete in default namespace
 			By("Creating first deployment for pod-delete chaos")
-			if err := pkg.CreateDeployment(clients, "testapp1", "nginx:1.12", "default"); err != nil {
-				log.Fatalf("Operator status check failed, due to %v", err)
-			}
+			err = pkg.CreateDeployment(clients, "testapp1", "nginx:1.12", "default")
+			Expect(err).To(BeNil(), "create testapp1 deployment, due to {%v}", err)
 
 			//Waiting for deployment to get ready
-			if err := pkg.DeploymentStatusCheck(&testsDetails, "testapp1", "default", clients); err != nil {
-				log.Fatalf("Error Timeout, %v", err)
-			}
+			err = pkg.DeploymentStatusCheck(&testsDetails, "testapp1", "default", clients)
+			Expect(err).To(BeNil(), "Error Timeout, due to {%v}", err)
 
 			//Creating second application for container-kill in default namespace
 			By("Creating second deployment for container-kill chaos")
-			if err := pkg.CreateDeployment(clients, "testapp2", "nginx:1.12", "litmus"); err != nil {
-				log.Fatalf("Operator status check failed, due to %v", err)
-			}
+			err = pkg.CreateDeployment(clients, "testapp2", "nginx:1.12", "litmus")
+			Expect(err).To(BeNil(), "create testapp2 deployment, due to {%v}", err)
 
 			//Waiting for deployment to get ready
-			if err := pkg.DeploymentStatusCheck(&testsDetails, "testapp2", "default", clients); err != nil {
-				log.Fatalf("Error Timeout, %v", err)
-			}
+			err = pkg.DeploymentStatusCheck(&testsDetails, "testapp2", "default", clients)
+			Expect(err).To(BeNil(), "Error Timeout, due to {%v}", err)
 
 			////////////////////////////////////////////////////////
 			//   Prepare Two Chaos Experiments at the same time  //
@@ -81,14 +75,13 @@ var _ = Describe("BDD of operator reconcile resiliency check", func() {
 			By("[Install]: Install rbac for pod-delete chaos")
 			testsDetails.ChaosNamespace = "default"
 			//Fetching all the default ENV
-			if err := pkg.InstallGoRbac(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install rbac, due to %v", err)
-			}
+			err = pkg.InstallGoRbac(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install rbac, due to {%v}", err)
+
 			//Installing Chaos Experiment for pod-delete
 			By("[Install]: Installing chaos experiment")
-			if err := pkg.InstallGoChaosExperiment(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaos experiment, due to %v", err)
-			}
+			err = pkg.InstallGoChaosExperiment(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos experiment, due to {%v}", err)
 
 			//Fetching all the default ENV
 			//Note: please don't provide custom experiment name here
@@ -99,14 +92,14 @@ var _ = Describe("BDD of operator reconcile resiliency check", func() {
 
 			//Installing RBAC for first chaos experiment that is container-kill
 			By("[Install]: Install rbac for pod-delete chaos")
-			if err := pkg.InstallGoRbac(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install rbac, due to %v", err)
-			}
+			err = pkg.InstallGoRbac(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install rbac, due to {%v}", err)
+
 			//Installing Chaos Experiment for container-kill
 			By("[Install]: Installing chaos experiment")
-			if err := pkg.InstallGoChaosExperiment(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaos experiment, due to %v", err)
-			}
+			err = pkg.InstallGoChaosExperiment(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos experiment, due to {%v}", err)
+
 			/////////////////////////////////////////////////////
 			//   Check the runner pod status for both chaos   ///
 			/////////////////////////////////////////////////////
@@ -114,14 +107,13 @@ var _ = Describe("BDD of operator reconcile resiliency check", func() {
 			//Creating Chaos-Engine for container-kill
 			By("[Install]: Install Chaos Engine for container-kill")
 			testsDetails.AppLabel = "run=testapp2"
-			if err := pkg.InstallGoChaosEngine(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaosengine, due to %v", err)
-			}
+			err = pkg.InstallGoChaosEngine(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaosengine, due to {%v}", err)
+
 			//Checking the runner pod status
 			By("[Status]: Runner pod running status check")
-			if _, err := pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Runner pod status check failed, due to %v", err)
-			}
+			_, err = pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Fetching all the default ENV
 			//Note: please don't provide custom experiment name here
@@ -134,16 +126,14 @@ var _ = Describe("BDD of operator reconcile resiliency check", func() {
 			By("[Install]: Install Chaos Engine for pod-delete")
 			testsDetails.AppLabel = "run=testapp1"
 			testsDetails.AppNS = "default"
-			if err := pkg.InstallGoChaosEngine(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaosengine, due to %v", err)
-			}
+			err = pkg.InstallGoChaosEngine(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaosengine, due to {%v}", err)
 
 			// Checking the runner pod status
 			By("[Status]: Runner pod running status check")
 			testsDetails.AppNS = "default"
-			if _, err := pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Runner pod status check failed, due to %v", err)
-			}
+			_, err = pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Visualising the components at default namespace
 			By("Getting the components in default namespace")

--- a/pkg/environment/clienset.go
+++ b/pkg/environment/clienset.go
@@ -7,6 +7,7 @@ import (
 	chaosClient "github.com/litmuschaos/chaos-operator/pkg/client/clientset/versioned/typed/litmuschaos/v1alpha1"
 	"github.com/pkg/errors"
 	"k8s.io/client-go/kubernetes"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )

--- a/pkg/install.go
+++ b/pkg/install.go
@@ -3,7 +3,6 @@ package pkg
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"os/exec"
 	"time"
 
@@ -39,7 +38,7 @@ func InstallAnsibleRbac(testsDetails *types.TestDetails, rbacNamespace string) e
 	if err != nil {
 		klog.Infof(fmt.Sprint(err) + ": " + stderr.String())
 		klog.Infof("Error: %v", err)
-		os.Exit(1)
+		errors.Errorf("Fail to create the rbac file, due to {%v}", err)
 	}
 	klog.Infof("[RBAC]: " + out.String())
 	klog.Info("[RBAC]: Rbac installed successfully !!!")
@@ -68,7 +67,7 @@ func InstallAnsibleChaosExperiment(testsDetails *types.TestDetails, experimentNa
 	if err != nil {
 		klog.Infof(fmt.Sprint(err) + ": " + stderr.String())
 		klog.Infof("Error: %v", err)
-		os.Exit(1)
+		errors.Errorf("Fail to create the experiment file, due to {%v}", err)
 	}
 	klog.Infof("[ChaosExperiment]: " + out.String())
 	klog.Info("[ChaosExperiment]: Chaos Experiment created successfully with image: " + testsDetails.AnsibleExperimentImage + " !!!")
@@ -125,7 +124,7 @@ func InstallAnsibleChaosEngine(testsDetails *types.TestDetails, engineNamespace 
 	if err != nil {
 		klog.Infof(fmt.Sprint(err) + ": " + stderr.String())
 		klog.Infof("Error: %v", err)
-		os.Exit(1)
+		errors.Errorf("Fail to create the engine file, due to {%v}", err)
 	}
 	klog.Infof("[ChaosEngine]: " + out.String())
 	time.Sleep(2 * time.Second)
@@ -156,7 +155,7 @@ func InstallGoRbac(testsDetails *types.TestDetails, rbacNamespace string) error 
 	if err != nil {
 		klog.Infof(fmt.Sprint(err) + ": " + stderr.String())
 		klog.Infof("Error: %v", err)
-		os.Exit(1)
+		errors.Errorf("Fail to create the rbac file, due to {%v}", err)
 	}
 	klog.Infof("[RBAC]: " + out.String())
 	klog.Info("[RBAC]: Rbac installed successfully !!!")
@@ -185,7 +184,7 @@ func InstallGoChaosExperiment(testsDetails *types.TestDetails, experimentNamespa
 	if err != nil {
 		klog.Infof(fmt.Sprint(err) + ": " + stderr.String())
 		klog.Infof("Error: %v", err)
-		os.Exit(1)
+		errors.Errorf("Fail to create the experiment file, due to {%v}", err)
 	}
 	klog.Infof("[ChaosExperiment]: " + out.String())
 	klog.Info("[ChaosExperiment]: Chaos Experiment created successfully with image: " + testsDetails.GoExperimentImage + " !!!")
@@ -246,7 +245,7 @@ func InstallGoChaosEngine(testsDetails *types.TestDetails, engineNamespace strin
 	if err != nil {
 		klog.Infof(fmt.Sprint(err) + ": " + stderr.String())
 		klog.Infof("Error: %v", err)
-		os.Exit(1)
+		errors.Errorf("Fail to create the engine file, due to {%v}", err)
 	}
 	klog.Infof("[ChaosEngine]: " + out.String())
 	time.Sleep(2 * time.Second)
@@ -281,7 +280,7 @@ func InstallLitmus(testsDetails *types.TestDetails) error {
 	if err != nil {
 		klog.Infof(fmt.Sprint(err) + ": " + stderr.String())
 		klog.Infof("Error: %v", err)
-		os.Exit(1)
+		errors.Errorf("Fail to create the installation file, due to {%v}", err)
 	}
 	klog.Infof("Result: " + out.String())
 
@@ -313,7 +312,7 @@ func InstallAdminRbac(testsDetails *types.TestDetails) error {
 	if err != nil {
 		klog.Infof(fmt.Sprint(err) + ": " + stderr.String())
 		klog.Infof("Error: %v", err)
-		os.Exit(1)
+		errors.Errorf("Fail to create the admin rbac file, due to {%v}", err)
 	}
 	klog.Infof("[RBAC]: " + out.String())
 	klog.Info("[RBAC]: Rbac installed successfully !!!")

--- a/tests/app-cleanup_test.go
+++ b/tests/app-cleanup_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"log"
 	"os/exec"
 	"testing"
 
@@ -33,9 +32,8 @@ var _ = Describe("BDD of Application Cleanup", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				klog.Infof("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig due to {%v}", err)
 
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")
@@ -44,14 +42,12 @@ var _ = Describe("BDD of Application Cleanup", func() {
 
 			//Removing Application
 			By("Deleting Application")
-			if err := exec.Command("kubectl", "delete", "-f", "../nginx/nginx.yml").Run(); err != nil {
-				log.Fatalf("Failed to delete application and its components,due to %v", err)
-			}
+			err = exec.Command("kubectl", "delete", "-f", "../nginx/nginx.yml").Run()
+			Expect(err).To(BeNil(), "Fail to delete application and its components, due to {%v}", err)
 
 			//Get the status of sample Application
-			if err := pkg.DeploymentCleanupCheck(&testsDetails, "nginx", clients); err != nil {
-				log.Fatalf("Application Status check faied,due to %v", err)
-			}
+			err = pkg.DeploymentCleanupCheck(&testsDetails, "nginx", clients)
+			Expect(err).To(BeNil(), "Application Status check faied, due to {%v}", err)
 
 		})
 	})

--- a/tests/app-deploy_test.go
+++ b/tests/app-deploy_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"log"
 	"os/exec"
 	"testing"
 
@@ -33,9 +32,8 @@ var _ = Describe("BDD of Application Deployment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				klog.Infof("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
 
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")
@@ -44,15 +42,13 @@ var _ = Describe("BDD of Application Deployment", func() {
 
 			//Deploying Sample application
 			By("Deploying Sample Application")
-			if err := exec.Command("kubectl", "apply", "-f", "../nginx/nginx.yml").Run(); err != nil {
-				log.Fatalf("Failed to cleate application and its components,due to %v", err)
-			}
+			err = exec.Command("kubectl", "apply", "-f", "../nginx/nginx.yml").Run()
+			Expect(err).To(BeNil(), "Fail to create application and its components, due to {%v}", err)
 
 			//Get the status of nginx Application
 			By("Running Deployment Status Check")
-			if err := pkg.DeploymentStatusCheck(&testsDetails, "nginx", "litmus", clients); err != nil {
-				log.Fatalf("Application Status check faied,due to %v", err)
-			}
+			err = pkg.DeploymentStatusCheck(&testsDetails, "nginx", "litmus", clients)
+			Expect(err).To(BeNil(), "Application Status check faied, due to {%v}", err)
 
 		})
 	})

--- a/tests/app-liveness_test.go
+++ b/tests/app-liveness_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"log"
 	"os/exec"
 	"testing"
 
@@ -34,9 +33,8 @@ var _ = Describe("BDD of Application Deployment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				klog.Infof("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
 
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")
@@ -45,15 +43,14 @@ var _ = Describe("BDD of Application Deployment", func() {
 
 			//Deploying liveness for application
 			By("Deploying liveness pod for the applicaiton")
-			if err := exec.Command("kubectl", "apply", "-f", "../nginx/liveness.yml").Run(); err != nil {
-				log.Fatalf("Failed to install liveness probe,due to %v", err)
-			}
+			err = exec.Command("kubectl", "apply", "-f", "../nginx/liveness.yml").Run()
+			Expect(err).To(BeNil(), "Fail to install liveness probe, due to {%v}", err)
 
 			//Get the status of liveness pod
 			By("liveness pod status check")
-			if err := pkg.PodStatusCheck(&testsDetails, clients); err != nil {
-				log.Fatalf("liveness pod status check faied,due to %v", err)
-			}
+			err = pkg.PodStatusCheck(&testsDetails, clients)
+			Expect(err).To(BeNil(), "iveness pod status check faied, due to {%v}", err)
+
 			klog.Info("Liveness pod established successfully !!!")
 
 		})

--- a/tests/auxiliary-app_test.go
+++ b/tests/auxiliary-app_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"log"
 	"os/exec"
 	"testing"
 
@@ -34,9 +33,8 @@ var _ = Describe("BDD of Auxilary app Deployment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				klog.Infof("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
 
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")
@@ -45,15 +43,14 @@ var _ = Describe("BDD of Auxilary app Deployment", func() {
 
 			//Deploying testpod application
 			By("Creating auxiliary application")
-			if err := exec.Command("kubectl", "run", "testpod", "--image=nginx", "-n", testsDetails.ChaosNamespace).Run(); err != nil {
-				log.Fatalf("Fail to deploy auxiliary app,due to %v", err)
-			}
+			err = exec.Command("kubectl", "run", "testpod", "--image=nginx", "-n", testsDetails.ChaosNamespace).Run()
+			Expect(err).To(BeNil(), "Fail to deploy auxiliary app, due to {%v}", err)
 
 			//Get the status of testpod Application
 			By("Running Deployment Status Check")
-			if err := pkg.DeploymentStatusCheck(&testsDetails, "testpod", "litmus", clients); err != nil {
-				log.Fatalf("Application Status check faied,due to %v", err)
-			}
+			err = pkg.DeploymentStatusCheck(&testsDetails, "testpod", "litmus", clients)
+			Expect(err).To(BeNil(), "Application Status check faied, due to {%v}", err)
+
 			klog.Infof("Auxiliary Application installed successfully")
 
 		})

--- a/tests/container-kill_test.go
+++ b/tests/container-kill_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"log"
 	"testing"
 
 	"github.com/litmuschaos/litmus-e2e/pkg"
@@ -32,9 +31,8 @@ var _ = Describe("BDD of container-kill experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				klog.Infof("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
 
 			//Fetching all the default ENV
 			//Note: please don't provide custom experiment name here
@@ -44,46 +42,39 @@ var _ = Describe("BDD of container-kill experiment", func() {
 
 			// Checking the chaos operator running status
 			By("[Status]: Checking chaos operator status")
-			if err := pkg.OperatorStatusCheck(&testsDetails, clients); err != nil {
-				log.Fatalf("Operator status check failed, due to %v", err)
-			}
+			err = pkg.OperatorStatusCheck(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Operator status check failed, due to {%v}", err)
 
 			//Installing RBAC for the experiment
 			By("[Install]: Installing RBAC")
-			if err := pkg.InstallGoRbac(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install rbac, due to %v", err)
-			}
+			err = pkg.InstallGoRbac(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install rbac, due to {%v}", err)
 
 			//Installing Chaos Experiment for container-kill
 			By("[Install]: Installing chaos experiment")
-			if err := pkg.InstallGoChaosExperiment(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaos experiment, due to %v", err)
-			}
+			err = pkg.InstallGoChaosExperiment(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos experiment, due to {%v}", err)
 
 			//Installing Chaos Engine for container-kill
 			By("[Install]: Installing chaos engine")
-			if err := pkg.InstallGoChaosEngine(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaosengine, due to %v", err)
-			}
+			err = pkg.InstallGoChaosEngine(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaosengine, due to {%v}", err)
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			if _, err := pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Runner pod status check failed, due to %v", err)
-			}
+			_, err = pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Waiting for experiment job to get completed
 			//And Print the logs of the job pod (chaos pod)
 			By("[Status]: Wait for job completion and then print logs")
-			if _, err := pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Fail to get the experiment job pod logs, due to %v", err)
-			}
+			_, err = pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Fail to get the experiment job pod logs, due to {%v}", err)
 
 			//Checking the chaosresult verdict
 			By("[Verdict]: Checking the chaosresult verdict")
-			if _, err := pkg.ChaosResultVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChasoResult Verdict check failed, due to %v", err)
-			}
+			_, err = pkg.ChaosResultVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 
 		})
 	})
@@ -97,9 +88,8 @@ var _ = Describe("BDD of container-kill experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				log.Fatalf("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
 
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")
@@ -108,10 +98,8 @@ var _ = Describe("BDD of container-kill experiment", func() {
 
 			//Checking chaosengine verdict
 			By("Checking the Verdict of Chaos Engine")
-			if _, err := pkg.ChaosEngineVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChaosEngine Verdict check failed, due to %v", err)
-			}
-
+			_, err = pkg.ChaosEngineVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
 		})
 	})
 
@@ -125,27 +113,25 @@ var _ = Describe("BDD of container-kill experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				log.Fatalf("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
 
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")
 			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
 			environment.GetENV(&testsDetails, "container-kill", "go-engine1")
 
-			//Updating the pipeline result table
-			By("Updating the pipeline result table")
 			//Getting chaosengine verdict
 			By("Getting Verdict of Chaos Engine")
 			ChaosEngineVerdict, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
-			if err != nil {
-				log.Fatalf("Getting ChaosEngine Verdict failed, due to %v", err)
-			}
+			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+			Expect(ChaosEngineVerdict).NotTo(BeEmpty(), "Fail to get chaos engine verdict, due to {%v}", err)
 
-			if err := pkg.UpdateResultTable("Kill one container in the application pod", ChaosEngineVerdict, &testsDetails); err != nil {
-				log.Fatalf("Job Result table updation failed, due to %v", err)
-			}
+			//Updating the pipeline result table
+			By("Updating the pipeline result table")
+			err = pkg.UpdateResultTable("Kill one container in the application pod", ChaosEngineVerdict, &testsDetails)
+			Expect(err).To(BeNil(), "Job Result Updation failed, due to {%v}", err)
+
 		})
 	})
 })

--- a/tests/disk-fill_test.go
+++ b/tests/disk-fill_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"log"
 	"testing"
 
 	"github.com/litmuschaos/litmus-e2e/pkg"
@@ -32,9 +31,8 @@ var _ = Describe("BDD of disk-fill experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				klog.Infof("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
 
 			//Fetching all the default ENV
 			//Note: please don't provide custom experiment name here
@@ -44,46 +42,39 @@ var _ = Describe("BDD of disk-fill experiment", func() {
 
 			// Checking the chaos operator running status
 			By("[Status]: Checking chaos operator status")
-			if err := pkg.OperatorStatusCheck(&testsDetails, clients); err != nil {
-				log.Fatalf("Operator status check failed, due to %v", err)
-			}
+			err = pkg.OperatorStatusCheck(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Operator status check failed, due to {%v}", err)
 
 			//Installing RBAC for the experiment
 			By("[Install]: Installing RBAC")
-			if err := pkg.InstallGoRbac(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install rbac, due to %v", err)
-			}
+			err = pkg.InstallGoRbac(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install rbac, due to {%v}", err)
 
 			//Installing Chaos Experiment for disk-fill
 			By("[Install]: Installing chaos experiment")
-			if err := pkg.InstallGoChaosExperiment(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaos experiment, due to %v", err)
-			}
+			err = pkg.InstallGoChaosExperiment(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos experiment, due to {%v}", err)
 
 			//Installing Chaos Engine for disk-fill
 			By("[Install]: Installing chaos engine")
-			if err := pkg.InstallGoChaosEngine(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaosengine, due to %v", err)
-			}
+			err = pkg.InstallGoChaosEngine(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaosengine, due to {%v}", err)
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			if _, err := pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Runner pod status check failed, due to %v", err)
-			}
+			_, err = pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Waiting for experiment job to get completed
 			//And Print the logs of the job pod (chaos pod)
 			By("[Status]: Wait for job completion and then print logs")
-			if _, err := pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Fail to get the experiment job pod logs, due to %v", err)
-			}
+			_, err = pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Fail to get the experiment job pod logs, due to {%v}", err)
 
 			//Checking the chaosresult verdict
 			By("[Verdict]: Checking the chaosresult verdict")
-			if _, err := pkg.ChaosResultVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChasoResult Verdict check failed, due to %v", err)
-			}
+			_, err = pkg.ChaosResultVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 
 		})
 	})
@@ -97,9 +88,8 @@ var _ = Describe("BDD of disk-fill experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				log.Fatalf("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
 
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")
@@ -108,10 +98,8 @@ var _ = Describe("BDD of disk-fill experiment", func() {
 
 			//Checking chaosengine verdict
 			By("Checking the Verdict of Chaos Engine")
-			if _, err := pkg.ChaosEngineVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChaosEngine Verdict check failed, due to %v", err)
-			}
-
+			_, err = pkg.ChaosEngineVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
 		})
 	})
 
@@ -125,27 +113,27 @@ var _ = Describe("BDD of disk-fill experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				log.Fatalf("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
 
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")
 			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
 			environment.GetENV(&testsDetails, "disk-fill", "go-engine2")
 
-			//Updating the pipeline result table
-			By("Updating the pipeline result table")
+			//Getting chaosengine verdict
+			By("Getting Verdict of Chaos Engine")
 			//Getting chaosengine verdict
 			By("Getting Verdict of Chaos Engine")
 			ChaosEngineVerdict, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
-			if err != nil {
-				log.Fatalf("Getting ChaosEngine Verdict failed, due to %v", err)
-			}
+			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+			Expect(ChaosEngineVerdict).NotTo(BeEmpty(), "Fail to get chaos engine verdict, due to {%v}", err)
 
-			if err := pkg.UpdateResultTable("Disk Fill Fills up Ephemeral Storage of a Pod", ChaosEngineVerdict, &testsDetails); err != nil {
-				log.Fatalf("Job Result table updation failed, due to %v", err)
-			}
+			//Updating the pipeline result table
+			By("Updating the pipeline result table")
+			err = pkg.UpdateResultTable("Disk Fill Fills up Ephemeral Storage of a Pod", ChaosEngineVerdict, &testsDetails)
+			Expect(err).To(BeNil(), "Job Result Updation failed, due to {%v}", err)
+
 		})
 	})
 })

--- a/tests/install-litmus_test.go
+++ b/tests/install-litmus_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"log"
 	"testing"
 
 	"github.com/litmuschaos/litmus-e2e/pkg"
@@ -32,9 +31,8 @@ var _ = Describe("BDD of Litmus installation", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				klog.Infof("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
 
 			//Fetching all the default ENV
 			//Note: please don't provide custom experiment name here
@@ -44,16 +42,13 @@ var _ = Describe("BDD of Litmus installation", func() {
 
 			//Installing Litmus
 			By("Installing Litmus")
-			if err := pkg.InstallLitmus(&testsDetails); err != nil {
-				log.Fatalf("Litmus installation failed, due to %v", err)
-			}
+			err = pkg.InstallLitmus(&testsDetails)
+			Expect(err).To(BeNil(), "Litmus installation failed, due to {%v}", err)
 
 			// Checking the chaos operator running status
 			By("[Status]: Checking chaos operator status")
-			if err := pkg.OperatorStatusCheck(&testsDetails, clients); err != nil {
-				log.Fatalf("Operator status check failed, due to %v", err)
-			}
-
+			err = pkg.OperatorStatusCheck(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Operator status check failed, due to {%v}", err)
 		})
 	})
 

--- a/tests/kubelet-service-kill_test.go
+++ b/tests/kubelet-service-kill_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"log"
 	"testing"
 
 	"github.com/litmuschaos/litmus-e2e/pkg"
@@ -30,12 +29,10 @@ var _ = Describe("BDD of kubelet-service-kill experiment", func() {
 			testsDetails := types.TestDetails{}
 			clients := environment.ClientSets{}
 
-			var err error
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				klog.Infof("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
 
 			//Fetching all the default ENV
 			//Note: please don't provide custom experiment name here
@@ -45,69 +42,80 @@ var _ = Describe("BDD of kubelet-service-kill experiment", func() {
 
 			// Checking the chaos operator running status
 			By("[Status]: Checking chaos operator status")
-			if err := pkg.OperatorStatusCheck(&testsDetails, clients); err != nil {
-				log.Fatalf("Operator status check failed, due to %v", err)
-			}
+			err = pkg.OperatorStatusCheck(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Operator status check failed, due to {%v}", err)
 
 			// Getting application node name
 			By("[Prepare]: Getting application node name")
-			if _, err := pkg.GetApplicationNode(&testsDetails, clients); err != nil {
-				log.Fatalf("Unable to get application node name, due to %v", err)
-			}
+			_, err = pkg.GetApplicationNode(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Unable to get application node name due to {%v}", err)
 
 			// Getting other node for nodeSelector in engine
-			if testsDetails.NodeSelectorName, err = pkg.GetSelectorNode(&testsDetails, clients); err != nil || testsDetails.NodeSelectorName == "" {
-				log.Fatalf("Unable to get node name for node selector, due to %v", err)
-			}
+			testsDetails.NodeSelectorName, err = pkg.GetSelectorNode(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Error in getting node selector name, due to {%v}", err)
+			Expect(testsDetails.NodeSelectorName).NotTo(BeEmpty(), "Unable to get node name for node selector, due to {%v}", err)
 
 			//Cordon the application node
 			By("Cordoning Application Node")
-			if err := pkg.NodeCordon(&testsDetails); err != nil {
-				log.Fatalf("Failed NodeCordon, due to %v", err)
-			}
+			err = pkg.NodeCordon(&testsDetails)
+			Expect(err).To(BeNil(), "Fail to Cordon the app node, due to {%v}", err)
 
 			//Installing RBAC for the experiment
 			By("[Install]: Installing RBAC")
-			if err := pkg.InstallGoRbac(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install rbac, due to %v", err)
-			}
+			err = pkg.InstallGoRbac(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install rbac, due to {%v}", err)
 
 			//Installing Chaos Experiment for kubelet-service-kill
 			By("[Install]: Installing chaos experiment")
-			if err := pkg.InstallGoChaosExperiment(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaos experiment, due to %v", err)
-			}
+			err = pkg.InstallGoChaosExperiment(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos experiment, due to {%v}", err)
 
 			//Installing Chaos Engine for kubelet-service-kill
 			By("[Install]: Installing chaos engine")
-			if err := pkg.InstallGoChaosEngine(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaosengine, due to %v", err)
-			}
+			err = pkg.InstallGoChaosEngine(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaosengine, due to {%v}", err)
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			if _, err := pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Runner pod status check failed, due to %v", err)
-			}
+			_, err = pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Waiting for experiment job to get completed
 			//And Print the logs of the job pod (chaos pod)
 			By("[Status]: Wait for job completion and then print logs")
-			if _, err := pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Fail to get the experiment job pod logs, due to %v", err)
-			}
+			_, err = pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Fail to get the experiment job pod logs, due to {%v}", err)
 
 			//Checking the chaosresult verdict
 			By("[Verdict]: Checking the chaosresult verdict")
-			if _, err := pkg.ChaosResultVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChasoResult Verdict check failed, due to %v", err)
-			}
+			_, err = pkg.ChaosResultVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
+		})
+	})
+
+	//Waiting for experiment job to get completed
+	// BDD for uncordoning the application node
+	Context("Check for application node", func() {
+
+		It("Should uncordon the app node", func() {
+
+			testsDetails := types.TestDetails{}
+			clients := environment.ClientSets{}
+
+			//Getting kubeConfig and Generate ClientSets
+			By("[PreChaos]: Getting kubeconfig and generate clientset")
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig due to {%v}", err)
+
+			// Getting application node name
+			By("[Prepare]: Getting application node name")
+			_, err = pkg.GetApplicationNode(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Unable to get application node name due to {%v}", err)
 
 			//Uncordon the application node
 			By("Uncordoning Application Node")
-			if err := pkg.NodeUncordon(&testsDetails); err != nil {
-				log.Fatalf("Failed NodeUncordon, due to %v", err)
-			}
+			err = pkg.NodeUncordon(&testsDetails)
+			Expect(err).To(BeNil(), "Fail to uncordon the app node, due to {%v}", err)
 
 		})
 	})
@@ -121,9 +129,8 @@ var _ = Describe("BDD of kubelet-service-kill experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				log.Fatalf("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig due to {%v}", err)
 
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")
@@ -132,9 +139,8 @@ var _ = Describe("BDD of kubelet-service-kill experiment", func() {
 
 			//Checking chaosengine verdict
 			By("Checking the Verdict of Chaos Engine")
-			if _, err := pkg.ChaosEngineVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChaosEngine Verdict check failed, due to %v", err)
-			}
+			_, err = pkg.ChaosEngineVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
 
 		})
 	})
@@ -148,27 +154,25 @@ var _ = Describe("BDD of kubelet-service-kill experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				log.Fatalf("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig due to {%v}", err)
 
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")
 			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
 			environment.GetENV(&testsDetails, "kubelet-service-kill", "go-engine3")
 
-			//Updating the pipeline result table
-			By("Updating the pipeline result table")
 			//Getting chaosengine verdict
 			By("Getting Verdict of Chaos Engine")
 			ChaosEngineVerdict, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
-			if err != nil {
-				log.Fatalf("Getting ChaosEngine Verdict failed, due to %v", err)
-			}
+			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+			Expect(ChaosEngineVerdict).NotTo(BeEmpty(), "Fail to get chaos engine verdict, due to {%v}", err)
 
-			if err := pkg.UpdateResultTable("Kills the kubelet service on the application node", ChaosEngineVerdict, &testsDetails); err != nil {
-				log.Fatalf("Job Result table updation failed, due to %v", err)
-			}
+			//Updating the pipeline result table
+			By("Updating the pipeline result table")
+			err = pkg.UpdateResultTable("Kills the kubelet service on the application node", ChaosEngineVerdict, &testsDetails)
+			Expect(err).To(BeNil(), "Job Result Updation failed, due to {%v}", err)
+
 		})
 	})
 })

--- a/tests/litmus-cleanup_test.go
+++ b/tests/litmus-cleanup_test.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"fmt"
-	"log"
 	"os/exec"
 	"testing"
 
@@ -34,9 +33,8 @@ var _ = Describe("BDD of litmus cleanup", func() {
 			var err error
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				log.Fatalf("Unable to Get the kubeconfig due to %v", err)
-			}
+			err = clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
 
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")

--- a/tests/node-cpu-hog_test.go
+++ b/tests/node-cpu-hog_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"log"
 	"testing"
 
 	"github.com/litmuschaos/litmus-e2e/pkg"
@@ -32,9 +31,8 @@ var _ = Describe("BDD of node-cpu-hog experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				klog.Infof("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
 
 			//Fetching all the default ENV
 			//Note: please don't provide custom experiment name here
@@ -44,46 +42,39 @@ var _ = Describe("BDD of node-cpu-hog experiment", func() {
 
 			// Checking the chaos operator running status
 			By("[Status]: Checking chaos operator status")
-			if err := pkg.OperatorStatusCheck(&testsDetails, clients); err != nil {
-				log.Fatalf("Operator status check failed, due to %v", err)
-			}
+			err = pkg.OperatorStatusCheck(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Operator status check failed, due to {%v}", err)
 
 			//Installing RBAC for the experiment
 			By("[Install]: Installing RBAC")
-			if err := pkg.InstallGoRbac(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install rbac, due to %v", err)
-			}
+			err = pkg.InstallGoRbac(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install rbac, due to {%v}", err)
 
 			//Installing Chaos Experiment for node-cpu-hog
 			By("[Install]: Installing chaos experiment")
-			if err := pkg.InstallGoChaosExperiment(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaos experiment, due to %v", err)
-			}
+			err = pkg.InstallGoChaosExperiment(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos experiment, due to {%v}", err)
 
 			//Installing Chaos Engine for node-cpu-hog
 			By("[Install]: Installing chaos engine")
-			if err := pkg.InstallGoChaosEngine(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaosengine, due to %v", err)
-			}
+			err = pkg.InstallGoChaosEngine(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaosengine, due to {%v}", err)
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			if _, err := pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Runner pod status check failed, due to %v", err)
-			}
+			_, err = pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Waiting for experiment job to get completed
 			//And Print the logs of the job pod (chaos pod)
 			By("[Status]: Wait for job completion and then print logs")
-			if _, err := pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Fail to get the experiment job pod logs, due to %v", err)
-			}
+			_, err = pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Fail to get the experiment job pod logs, due to {%v}", err)
 
 			//Checking the chaosresult verdict
 			By("[Verdict]: Checking the chaosresult verdict")
-			if _, err := pkg.ChaosResultVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChasoResult Verdict check failed, due to %v", err)
-			}
+			_, err = pkg.ChaosResultVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 
 		})
 	})
@@ -97,9 +88,8 @@ var _ = Describe("BDD of node-cpu-hog experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				log.Fatalf("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
 
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")
@@ -108,9 +98,8 @@ var _ = Describe("BDD of node-cpu-hog experiment", func() {
 
 			//Checking chaosengine verdict
 			By("Checking the Verdict of Chaos Engine")
-			if _, err := pkg.ChaosEngineVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChaosEngine Verdict check failed, due to %v", err)
-			}
+			_, err = pkg.ChaosEngineVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
 
 		})
 	})
@@ -125,27 +114,25 @@ var _ = Describe("BDD of node-cpu-hog experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				log.Fatalf("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
 
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")
 			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
 			environment.GetENV(&testsDetails, "node-cpu-hog", "go-engine4")
 
-			//Updating the pipeline result table
-			By("Updating the pipeline result table")
 			//Getting chaosengine verdict
 			By("Getting Verdict of Chaos Engine")
 			ChaosEngineVerdict, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
-			if err != nil {
-				log.Fatalf("Getting ChaosEngine Verdict failed, due to %v", err)
-			}
+			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+			Expect(ChaosEngineVerdict).NotTo(BeEmpty(), "Fail to get chaos engine verdict, due to {%v}", err)
 
-			if err := pkg.UpdateResultTable("Exhaust CPU resources on the Kubernetes Node", ChaosEngineVerdict, &testsDetails); err != nil {
-				log.Fatalf("Job Result table updation failed, due to %v", err)
-			}
+			//Updating the pipeline result table
+			By("Updating the pipeline result table")
+			err = pkg.UpdateResultTable("Exhaust CPU resources on the Kubernetes Node", ChaosEngineVerdict, &testsDetails)
+			Expect(err).To(BeNil(), "Job Result Updation failed, due to {%v}", err)
+
 		})
 	})
 })

--- a/tests/node-drain_test.go
+++ b/tests/node-drain_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"log"
 	"testing"
 
 	"github.com/litmuschaos/litmus-e2e/pkg"
@@ -29,12 +28,11 @@ var _ = Describe("BDD of node-drain experiment", func() {
 
 			testsDetails := types.TestDetails{}
 			clients := environment.ClientSets{}
-			var err error
+
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				klog.Infof("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
 
 			//Fetching all the default ENV
 			//Note: please don't provide custom experiment name here
@@ -44,69 +42,79 @@ var _ = Describe("BDD of node-drain experiment", func() {
 
 			// Checking the chaos operator running status
 			By("[Status]: Checking chaos operator status")
-			if err := pkg.OperatorStatusCheck(&testsDetails, clients); err != nil {
-				log.Fatalf("Operator status check failed, due to %v", err)
-			}
+			err = pkg.OperatorStatusCheck(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Operator status check failed, due to {%v}", err)
 
 			// Getting application node name
 			By("[Prepare]: Getting application node name")
-			if _, err := pkg.GetApplicationNode(&testsDetails, clients); err != nil {
-				log.Fatalf("Unable to get application node name, due to %v", err)
-			}
+			_, err = pkg.GetApplicationNode(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Unable to get application node name due to {%v}", err)
 
 			// Getting other node for nodeSelector in engine
-			if testsDetails.NodeSelectorName, err = pkg.GetSelectorNode(&testsDetails, clients); err != nil || testsDetails.NodeSelectorName == "" {
-				log.Fatalf("Unable to get node name for node selector, due to %v", err)
-			}
+			testsDetails.NodeSelectorName, err = pkg.GetSelectorNode(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Error in getting node selector name, due to {%v}", err)
+			Expect(testsDetails.NodeSelectorName).NotTo(BeEmpty(), "Unable to get node name for node selector, due to {%v}", err)
 
 			//Cordon the application node
 			By("Cordoning Application Node")
-			if err := pkg.NodeCordon(&testsDetails); err != nil {
-				log.Fatalf("Failed NodeCordon, due to %v", err)
-			}
+			err = pkg.NodeCordon(&testsDetails)
+			Expect(err).To(BeNil(), "Fail to Cordon the app node, due to {%v}", err)
 
 			//Installing RBAC for the experiment
 			By("[Install]: Installing RBAC")
-			if err := pkg.InstallGoRbac(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install rbac, due to %v", err)
-			}
+			err = pkg.InstallGoRbac(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install rbac, due to {%v}", err)
 
 			//Installing Chaos Experiment for node-cordon
 			By("[Install]: Installing chaos experiment")
-			if err := pkg.InstallGoChaosExperiment(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaos experiment, due to %v", err)
-			}
+			err = pkg.InstallGoChaosExperiment(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos experiment, due to {%v}", err)
 
 			//Installing Chaos Engine for node-cordon
 			By("[Install]: Installing chaos engine")
-			if err := pkg.InstallGoChaosEngine(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaosengine, due to %v", err)
-			}
+			err = pkg.InstallGoChaosEngine(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos engine, due to {%v}", err)
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			if _, err := pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Runner pod status check failed, due to %v", err)
-			}
+			_, err = pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Waiting for experiment job to get completed
 			//And Print the logs of the job pod (chaos pod)
 			By("[Status]: Wait for job completion and then print logs")
-			if _, err := pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Fail to get the experiment job pod logs, due to %v", err)
-			}
+			_, err = pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Fail to get the experiment job pod logs, due to {%v}", err)
 
 			//Checking the chaosresult verdict
 			By("[Verdict]: Checking the chaosresult verdict")
-			if _, err := pkg.ChaosResultVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChasoResult Verdict check failed, due to %v", err)
-			}
+			_, err = pkg.ChaosResultVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
+
+		})
+	})
+	// BDD for uncordoning the application node
+	Context("Check for application node", func() {
+
+		It("Should uncordon the app node", func() {
+
+			testsDetails := types.TestDetails{}
+			clients := environment.ClientSets{}
+
+			//Getting kubeConfig and Generate ClientSets
+			By("[PreChaos]: Getting kubeconfig and generate clientset")
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig due to {%v}", err)
+
+			// Getting application node name
+			By("[Prepare]: Getting application node name")
+			_, err = pkg.GetApplicationNode(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Unable to get application node name due to {%v}", err)
 
 			//Uncordon the application node
 			By("Uncordoning Application Node")
-			if err := pkg.NodeUncordon(&testsDetails); err != nil {
-				log.Fatalf("Failed NodeUncordon, due to %v", err)
-			}
+			err = pkg.NodeUncordon(&testsDetails)
+			Expect(err).To(BeNil(), "Fail to uncordon the app node, due to {%v}", err)
 
 		})
 	})
@@ -120,9 +128,8 @@ var _ = Describe("BDD of node-drain experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				log.Fatalf("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig due to {%v}", err)
 
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")
@@ -131,9 +138,8 @@ var _ = Describe("BDD of node-drain experiment", func() {
 
 			//Checking chaosengine verdict
 			By("Checking the Verdict of Chaos Engine")
-			if _, err := pkg.ChaosEngineVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChaosEngine Verdict check failed, due to %v", err)
-			}
+			_, err = pkg.ChaosEngineVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
 
 		})
 	})
@@ -147,27 +153,25 @@ var _ = Describe("BDD of node-drain experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				log.Fatalf("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig due to {%v}", err)
 
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")
 			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
 			environment.GetENV(&testsDetails, "node-drain", "go-engine5")
 
-			//Updating the pipeline result table
-			By("Updating the pipeline result table")
 			//Getting chaosengine verdict
 			By("Getting Verdict of Chaos Engine")
 			ChaosEngineVerdict, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
-			if err != nil {
-				log.Fatalf("Getting ChaosEngine Verdict failed, due to %v", err)
-			}
+			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+			Expect(ChaosEngineVerdict).NotTo(BeEmpty(), "Fail to get chaos engine verdict, due to {%v}", err)
 
-			if err := pkg.UpdateResultTable("Drain the node where application pod is scheduled", ChaosEngineVerdict, &testsDetails); err != nil {
-				log.Fatalf("Job Result table updation failed, due to %v", err)
-			}
+			//Updating the pipeline result table
+			By("Updating the pipeline result table")
+			err = pkg.UpdateResultTable("Drain the node where application pod is scheduled", ChaosEngineVerdict, &testsDetails)
+			Expect(err).To(BeNil(), "Job Result Updation failed, due to {%v}", err)
+
 		})
 	})
 })

--- a/tests/node-memory-hog_test.go
+++ b/tests/node-memory-hog_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"log"
 	"testing"
 
 	"github.com/litmuschaos/litmus-e2e/pkg"
@@ -32,9 +31,8 @@ var _ = Describe("BDD of node-memory-hog experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				klog.Infof("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
 
 			//Fetching all the default ENV
 			//Note: please don't provide custom experiment name here
@@ -44,46 +42,39 @@ var _ = Describe("BDD of node-memory-hog experiment", func() {
 
 			// Checking the chaos operator running status
 			By("[Status]: Checking chaos operator status")
-			if err := pkg.OperatorStatusCheck(&testsDetails, clients); err != nil {
-				log.Fatalf("Operator status check failed, due to %v", err)
-			}
+			err = pkg.OperatorStatusCheck(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Operator status check failed, due to {%v}", err)
 
 			//Installing RBAC for the experiment
 			By("[Install]: Installing RBAC")
-			if err := pkg.InstallGoRbac(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install rbac, due to %v", err)
-			}
+			err = pkg.InstallGoRbac(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install rbac, due to {%v}", err)
 
 			//Installing Chaos Experiment for node-memory-hog
 			By("[Install]: Installing chaos experiment")
-			if err := pkg.InstallGoChaosExperiment(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaos experiment, due to %v", err)
-			}
+			err = pkg.InstallGoChaosExperiment(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos experiment, due to {%v}", err)
 
 			//Installing Chaos Engine for node-memory-hog
 			By("[Install]: Installing chaos engine")
-			if err := pkg.InstallGoChaosEngine(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaosengine, due to %v", err)
-			}
+			err = pkg.InstallGoChaosEngine(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaosengine, due to {%v}", err)
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			if _, err := pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Runner pod status check failed, due to %v", err)
-			}
+			_, err = pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Waiting for experiment job to get completed
 			//And Print the logs of the job pod (chaos pod)
 			By("[Status]: Wait for job completion and then print logs")
-			if _, err := pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Fail to get the experiment job pod logs, due to %v", err)
-			}
+			_, err = pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Fail to get the experiment job pod logs, due to {%v}", err)
 
 			//Checking the chaosresult verdict
 			By("[Verdict]: Checking the chaosresult verdict")
-			if _, err := pkg.ChaosResultVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChasoResult Verdict check failed, due to %v", err)
-			}
+			_, err = pkg.ChaosResultVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 
 		})
 	})
@@ -97,9 +88,8 @@ var _ = Describe("BDD of node-memory-hog experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				log.Fatalf("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
 
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")
@@ -108,10 +98,8 @@ var _ = Describe("BDD of node-memory-hog experiment", func() {
 
 			//Checking chaosengine verdict
 			By("Checking the Verdict of Chaos Engine")
-			if _, err := pkg.ChaosEngineVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChaosEngine Verdict check failed, due to %v", err)
-			}
-
+			_, err = pkg.ChaosEngineVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
 		})
 	})
 	// BDD for pipeline result update
@@ -124,27 +112,25 @@ var _ = Describe("BDD of node-memory-hog experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				log.Fatalf("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
 
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")
 			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
 			environment.GetENV(&testsDetails, "node-memory-hog", "go-engine6")
 
-			//Updating the pipeline result table
-			By("Updating the pipeline result table")
 			//Getting chaosengine verdict
 			By("Getting Verdict of Chaos Engine")
 			ChaosEngineVerdict, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
-			if err != nil {
-				log.Fatalf("Getting ChaosEngine Verdict failed, due to %v", err)
-			}
+			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+			Expect(ChaosEngineVerdict).NotTo(BeEmpty(), "Fail to get chaos engine verdict, due to {%v}", err)
 
-			if err := pkg.UpdateResultTable("Exhaust Memory resources on the Kubernetes Node", ChaosEngineVerdict, &testsDetails); err != nil {
-				log.Fatalf("Job Result table updation failed, due to %v", err)
-			}
+			//Updating the pipeline result table
+			By("Updating the pipeline result table")
+			err = pkg.UpdateResultTable("Exhaust Memory resources on the Kubernetes Node", ChaosEngineVerdict, &testsDetails)
+			Expect(err).To(BeNil(), "Job Result Updation failed, due to {%v}", err)
+
 		})
 	})
 })

--- a/tests/node-taint_test.go
+++ b/tests/node-taint_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"log"
 	"testing"
 
 	"github.com/litmuschaos/litmus-e2e/pkg"
@@ -29,12 +28,11 @@ var _ = Describe("BDD of node-taint experiment", func() {
 
 			testsDetails := types.TestDetails{}
 			clients := environment.ClientSets{}
-			var err error
+
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				klog.Infof("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
 
 			//Fetching all the default ENV
 			//Note: please don't provide custom experiment name here
@@ -44,72 +42,83 @@ var _ = Describe("BDD of node-taint experiment", func() {
 
 			// Checking the chaos operator running status
 			By("[Status]: Checking chaos operator status")
-			if err := pkg.OperatorStatusCheck(&testsDetails, clients); err != nil {
-				log.Fatalf("Operator status check failed, due to %v", err)
-			}
+			err = pkg.OperatorStatusCheck(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Operator status check failed, due to {%v}", err)
 
 			// Getting application node name
 			By("[Prepare]: Getting application node name")
-			if _, err := pkg.GetApplicationNode(&testsDetails, clients); err != nil {
-				log.Fatalf("Unable to get application node name, due to %v", err)
-			}
+			_, err = pkg.GetApplicationNode(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Unable to get application node name due to {%v}", err)
 
 			// Getting other node for nodeSelector in engine
-			if testsDetails.NodeSelectorName, err = pkg.GetSelectorNode(&testsDetails, clients); err != nil || testsDetails.NodeSelectorName == "" {
-				log.Fatalf("Unable to get node name for node selector, due to %v", err)
-			}
+			testsDetails.NodeSelectorName, err = pkg.GetSelectorNode(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Error in getting node selector name, due to {%v}", err)
+			Expect(testsDetails.NodeSelectorName).NotTo(BeEmpty(), "Unable to get node name for node selector, due to {%v}", err)
 
 			//Cordon the application node
 			By("Cordoning Application Node")
-			if err := pkg.NodeCordon(&testsDetails); err != nil {
-				log.Fatalf("Failed NodeCordon, due to %v", err)
-			}
+			err = pkg.NodeCordon(&testsDetails)
+			Expect(err).To(BeNil(), "Fail to Cordon the app node, due to {%v}", err)
 
 			//Installing RBAC for the experiment
 			By("[Install]: Installing RBAC")
-			if err := pkg.InstallGoRbac(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install rbac, due to %v", err)
-			}
+			err = pkg.InstallGoRbac(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install rbac, due to {%v}", err)
 
 			//Installing Chaos Experiment for node-cordon
 			By("[Install]: Installing chaos experiment")
-			if err := pkg.InstallGoChaosExperiment(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaos experiment, due to %v", err)
-			}
+			err = pkg.InstallGoChaosExperiment(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos experiment, due to {%v}", err)
 
 			//Installing Chaos Engine for node-cordon
 			By("[Install]: Installing chaos engine")
-			if err := pkg.InstallGoChaosEngine(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaosengine, due to %v", err)
-			}
+			err = pkg.InstallGoChaosEngine(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos engine, due to {%v}", err)
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			if _, err := pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Runner pod status check failed, due to %v", err)
-			}
+			_, err = pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Waiting for experiment job to get completed
 			//And Print the logs of the job pod (chaos pod)
 			By("[Status]: Wait for job completion and then print logs")
-			if _, err := pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Fail to get the experiment job pod logs, due to %v", err)
-			}
+			_, err = pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Fail to get the experiment job pod logs, due to {%v}", err)
 
 			//Checking the chaosresult verdict
 			By("[Verdict]: Checking the chaosresult verdict")
-			if _, err := pkg.ChaosResultVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChasoResult Verdict check failed, due to %v", err)
-			}
-
-			//Uncordon the application node
-			By("Uncordoning Application Node")
-			if err := pkg.NodeUncordon(&testsDetails); err != nil {
-				log.Fatalf("Failed NodeUncordon, due to %v", err)
-			}
+			_, err = pkg.ChaosResultVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 
 		})
 	})
+	// BDD for uncordoning the application node
+	Context("Check for application node", func() {
+
+		It("Should uncordon the app node", func() {
+
+			testsDetails := types.TestDetails{}
+			clients := environment.ClientSets{}
+
+			//Getting kubeConfig and Generate ClientSets
+			By("[PreChaos]: Getting kubeconfig and generate clientset")
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig due to {%v}", err)
+
+			// Getting application node name
+			By("[Prepare]: Getting application node name")
+			_, err = pkg.GetApplicationNode(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Unable to get application node name due to {%v}", err)
+
+			//Uncordon the application node
+			By("Uncordoning Application Node")
+			err = pkg.NodeUncordon(&testsDetails)
+			Expect(err).To(BeNil(), "Fail to uncordon the app node, due to {%v}", err)
+
+		})
+	})
+
 	// BDD for checking chaosengine Verdict
 	Context("Check for chaos engine verdict", func() {
 
@@ -120,9 +129,8 @@ var _ = Describe("BDD of node-taint experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				log.Fatalf("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig due to {%v}", err)
 
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")
@@ -131,9 +139,8 @@ var _ = Describe("BDD of node-taint experiment", func() {
 
 			//Checking chaosengine verdict
 			By("Checking the Verdict of Chaos Engine")
-			if _, err := pkg.ChaosEngineVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChaosEngine Verdict check failed, due to %v", err)
-			}
+			_, err = pkg.ChaosEngineVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
 
 		})
 	})
@@ -147,27 +154,25 @@ var _ = Describe("BDD of node-taint experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				log.Fatalf("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig due to {%v}", err)
 
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")
 			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
 			environment.GetENV(&testsDetails, "node-taint", "go-engine7")
 
-			//Updating the pipeline result table
-			By("Updating the pipeline result table")
 			//Getting chaosengine verdict
 			By("Getting Verdict of Chaos Engine")
 			ChaosEngineVerdict, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
-			if err != nil {
-				log.Fatalf("Getting ChaosEngine Verdict failed, due to %v", err)
-			}
+			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+			Expect(ChaosEngineVerdict).NotTo(BeEmpty(), "Fail to get chaos engine verdict, due to {%v}", err)
 
-			if err := pkg.UpdateResultTable("Drain the node where application pod is scheduled", ChaosEngineVerdict, &testsDetails); err != nil {
-				log.Fatalf("Job Result table updation failed, due to %v", err)
-			}
+			//Updating the pipeline result table
+			By("Updating the pipeline result table")
+			err = pkg.UpdateResultTable("Drain the node where application pod is scheduled", ChaosEngineVerdict, &testsDetails)
+			Expect(err).To(BeNil(), "Job Result Updation failed, due to {%v}", err)
+
 		})
 	})
 })

--- a/tests/pipeline-update_test.go
+++ b/tests/pipeline-update_test.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"io/ioutil"
-	"log"
 	"strings"
 	"testing"
 
@@ -40,14 +39,13 @@ var _ = Describe("BDD of pipeline status update", func() {
 			By("Updating the pipeline status table")
 			var err error
 			coverageData, err := ioutil.ReadFile("../coverage")
-			if err != nil {
-				log.Fatalf("failed reading coverageData from file: %s", err)
-			}
+			Expect(err).To(BeNil(), "failed reading coverageData from file, due to {%v}", err)
+
 			lines := strings.Split(string(coverageData), "\n")
 			klog.Infof("\nFile Content: %s\n", string(lines[0]))
-			if err = pkg.UpdatePipelineStatus(&testsDetails, string(lines[0])); err != nil {
-				log.Fatalf("Fail to run the script for pipeline status update,due to %v", err)
-			}
+			err = pkg.UpdatePipelineStatus(&testsDetails, string(lines[0]))
+			Expect(err).To(BeNil(), "Fail to run the script for pipeline status update,due to {%v}", err)
+
 			klog.Info("Pipeline status updated successfully !!!")
 
 		})

--- a/tests/pod-cpu-hog_test.go
+++ b/tests/pod-cpu-hog_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"log"
 	"testing"
 
 	"github.com/litmuschaos/litmus-e2e/pkg"
@@ -32,9 +31,8 @@ var _ = Describe("BDD of pod-cpu-hog experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				klog.Infof("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
 
 			//Fetching all the default ENV
 			//Note: please don't provide custom experiment name here
@@ -44,46 +42,39 @@ var _ = Describe("BDD of pod-cpu-hog experiment", func() {
 
 			// Checking the chaos operator running status
 			By("[Status]: Checking chaos operator status")
-			if err := pkg.OperatorStatusCheck(&testsDetails, clients); err != nil {
-				log.Fatalf("Operator status check failed, due to %v", err)
-			}
+			err = pkg.OperatorStatusCheck(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Operator status check failed, due to {%v}", err)
 
 			//Installing RBAC for the experiment
 			By("[Install]: Installing RBAC")
-			if err := pkg.InstallGoRbac(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install rbac, due to %v", err)
-			}
+			err = pkg.InstallGoRbac(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install rbac, due to {%v}", err)
 
 			//Installing Chaos Experiment for pod-cpu-hog
 			By("[Install]: Installing chaos experiment")
-			if err := pkg.InstallGoChaosExperiment(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaos experiment, due to %v", err)
-			}
+			err = pkg.InstallGoChaosExperiment(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos experiment, due to {%v}", err)
 
 			//Installing Chaos Engine for pod-cpu-hog
 			By("[Install]: Installing chaos engine")
-			if err := pkg.InstallGoChaosEngine(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaosengine, due to %v", err)
-			}
+			err = pkg.InstallGoChaosEngine(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaosengine, due to {%v}", err)
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			if _, err := pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Runner pod status check failed, due to %v", err)
-			}
+			_, err = pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Waiting for experiment job to get completed
 			//And Print the logs of the job pod (chaos pod)
 			By("[Status]: Wait for job completion and then print logs")
-			if _, err := pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Fail to get the experiment job pod logs, due to %v", err)
-			}
+			_, err = pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Fail to get the experiment job pod logs, due to {%v}", err)
 
 			//Checking the chaosresult verdict
 			By("[Verdict]: Checking the chaosresult verdict")
-			if _, err := pkg.ChaosResultVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChasoResult Verdict check failed, due to %v", err)
-			}
+			_, err = pkg.ChaosResultVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 
 		})
 	})
@@ -97,9 +88,8 @@ var _ = Describe("BDD of pod-cpu-hog experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				log.Fatalf("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
 
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")
@@ -108,10 +98,8 @@ var _ = Describe("BDD of pod-cpu-hog experiment", func() {
 
 			//Checking chaosengine verdict
 			By("Checking the Verdict of Chaos Engine")
-			if _, err := pkg.ChaosEngineVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChaosEngine Verdict check failed, due to %v", err)
-			}
-
+			_, err = pkg.ChaosEngineVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
 		})
 	})
 
@@ -125,9 +113,8 @@ var _ = Describe("BDD of pod-cpu-hog experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				log.Fatalf("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
 
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")
@@ -136,9 +123,8 @@ var _ = Describe("BDD of pod-cpu-hog experiment", func() {
 
 			//Checking chaosengine verdict
 			By("Checking the Verdict of Chaos Engine")
-			if _, err := pkg.ChaosEngineVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChaosEngine Verdict check failed, due to %v", err)
-			}
+			_, err = pkg.ChaosEngineVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
 
 		})
 	})
@@ -152,27 +138,25 @@ var _ = Describe("BDD of pod-cpu-hog experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				log.Fatalf("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
 
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")
 			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
 			environment.GetENV(&testsDetails, "pod-cpu-hog", "go-engine8")
 
-			//Updating the pipeline result table
-			By("Updating the pipeline result table")
 			//Getting chaosengine verdict
 			By("Getting Verdict of Chaos Engine")
 			ChaosEngineVerdict, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
-			if err != nil {
-				log.Fatalf("Getting ChaosEngine Verdict failed, due to %v", err)
-			}
+			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+			Expect(ChaosEngineVerdict).NotTo(BeEmpty(), "Fail to get chaos engine verdict, due to {%v}", err)
 
-			if err := pkg.UpdateResultTable("Consume CPU resources on the application container", ChaosEngineVerdict, &testsDetails); err != nil {
-				log.Fatalf("Job Result table updation failed, due to %v", err)
-			}
+			//Updating the pipeline result table
+			By("Updating the pipeline result table")
+			err = pkg.UpdateResultTable("Consume CPU resources on the application container", ChaosEngineVerdict, &testsDetails)
+			Expect(err).To(BeNil(), "Job Result Updation failed, due to {%v}", err)
+
 		})
 	})
 })

--- a/tests/pod-delete_test.go
+++ b/tests/pod-delete_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"log"
 	"testing"
 
 	"github.com/litmuschaos/litmus-e2e/pkg"
@@ -31,9 +30,8 @@ var _ = Describe("BDD of pod-delete experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				klog.Infof("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
 
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")
@@ -42,46 +40,39 @@ var _ = Describe("BDD of pod-delete experiment", func() {
 
 			// Checking the chaos operator running status
 			By("[Status]: Checking chaos operator status")
-			if err := pkg.OperatorStatusCheck(&testsDetails, clients); err != nil {
-				log.Fatalf("Operator status check failed, due to %v", err)
-			}
+			err = pkg.OperatorStatusCheck(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Operator status check failed, due to {%v}", err)
 
 			//Installing RBAC for the experiment
 			By("[Install]: Installing RBAC")
-			if err := pkg.InstallGoRbac(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install rbac, due to %v", err)
-			}
+			err = pkg.InstallGoRbac(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install rbac, due to {%v}", err)
 
 			//Installing Chaos Experiment for pod-delete
 			By("[Install]: Installing chaos experiment")
-			if err := pkg.InstallGoChaosExperiment(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaos experiment, due to %v", err)
-			}
+			err = pkg.InstallGoChaosExperiment(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos experiment, due to {%v}", err)
 
 			//Installing Chaos Engine for pod-delete
 			By("[Install]: Installing chaos engine")
-			if err := pkg.InstallGoChaosEngine(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaos engine, due to %v", err)
-			}
+			err = pkg.InstallGoChaosEngine(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaosengine, due to {%v}", err)
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			if _, err := pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Runner pod status check failed, due to %v", err)
-			}
+			_, err = pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Waiting for experiment job to get completed
 			//And Print the logs of the job pod (chaos pod)
 			By("[Status]: Wait for job completion and then print logs")
-			if _, err := pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Fail to get the experiment job pod logs, due to %v", err)
-			}
+			_, err = pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Fail to get the experiment job pod logs, due to {%v}", err)
 
 			//Checking the chaosresult verdict
 			By("[Verdict]: Checking the chaosresult verdict")
-			if _, err := pkg.ChaosResultVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChasoResult Verdict check failed, due to %v", err)
-			}
+			_, err = pkg.ChaosResultVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 
 		})
 	})
@@ -95,9 +86,8 @@ var _ = Describe("BDD of pod-delete experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				log.Fatalf("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
 
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")
@@ -106,9 +96,8 @@ var _ = Describe("BDD of pod-delete experiment", func() {
 
 			//Checking chaosengine verdict
 			By("Checking the Verdict of Chaos Engine")
-			if _, err := pkg.ChaosEngineVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChaosEngine Verdict check failed, due to %v", err)
-			}
+			_, err = pkg.ChaosEngineVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
 
 		})
 	})
@@ -123,27 +112,25 @@ var _ = Describe("BDD of pod-delete experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				log.Fatalf("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
 
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")
 			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
 			environment.GetENV(&testsDetails, "pod-delete", "go-engine9")
 
-			//Updating the pipeline result table
-			By("Updating the pipeline result table")
 			//Getting chaosengine verdict
 			By("Getting Verdict of Chaos Engine")
 			ChaosEngineVerdict, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
-			if err != nil {
-				log.Fatalf("Getting ChaosEngine Verdict failed, due to %v", err)
-			}
+			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+			Expect(ChaosEngineVerdict).NotTo(BeEmpty(), "Fail to get chaos engine verdict, due to {%v}", err)
 
-			if err := pkg.UpdateResultTable("Pod Delete test fails the application pod", ChaosEngineVerdict, &testsDetails); err != nil {
-				log.Fatalf("Job Result table updation failed, due to %v", err)
-			}
+			//Updating the pipeline result table
+			By("Updating the pipeline result table")
+			err = pkg.UpdateResultTable("Pod Delete test fails the application pod", ChaosEngineVerdict, &testsDetails)
+			Expect(err).To(BeNil(), "Job Result Updation failed, due to {%v}", err)
+
 		})
 	})
 })

--- a/tests/pod-memory-hog_test.go
+++ b/tests/pod-memory-hog_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"log"
 	"testing"
 
 	"github.com/litmuschaos/litmus-e2e/pkg"
@@ -32,9 +31,8 @@ var _ = Describe("BDD of pod-memory-hog experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				klog.Infof("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
 
 			//Fetching all the default ENV
 			//Note: please don't provide custom experiment name here
@@ -44,46 +42,39 @@ var _ = Describe("BDD of pod-memory-hog experiment", func() {
 
 			// Checking the chaos operator running status
 			By("[Status]: Checking chaos operator status")
-			if err := pkg.OperatorStatusCheck(&testsDetails, clients); err != nil {
-				log.Fatalf("Operator status check failed, due to %v", err)
-			}
+			err = pkg.OperatorStatusCheck(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Operator status check failed, due to {%v}", err)
 
 			//Installing RBAC for the experiment
 			By("[Install]: Installing RBAC")
-			if err := pkg.InstallGoRbac(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install rbac, due to %v", err)
-			}
+			err = pkg.InstallGoRbac(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install rbac, due to {%v}", err)
 
 			//Installing Chaos Experiment for pod-memory-hog
 			By("[Install]: Installing chaos experiment")
-			if err := pkg.InstallGoChaosExperiment(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaos experiment, due to %v", err)
-			}
+			err = pkg.InstallGoChaosExperiment(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos experiment, due to {%v}", err)
 
 			//Installing Chaos Engine for pod-memory-hog
 			By("[Install]: Installing chaos engine")
-			if err := pkg.InstallGoChaosEngine(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaosengine, due to %v", err)
-			}
+			err = pkg.InstallGoChaosEngine(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaosengine, due to {%v}", err)
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			if _, err := pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Runner pod status check failed, due to %v", err)
-			}
+			_, err = pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Waiting for experiment job to get completed
 			//And Print the logs of the job pod (chaos pod)
 			By("[Status]: Wait for job completion and then print logs")
-			if _, err := pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Fail to get the experiment job pod logs, due to %v", err)
-			}
+			_, err = pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Fail to get the experiment job pod logs, due to {%v}", err)
 
 			//Checking the chaosresult verdict
 			By("[Verdict]: Checking the chaosresult verdict")
-			if _, err := pkg.ChaosResultVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChasoResult Verdict check failed, due to %v", err)
-			}
+			_, err = pkg.ChaosResultVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 
 		})
 	})
@@ -97,9 +88,8 @@ var _ = Describe("BDD of pod-memory-hog experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				log.Fatalf("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
 
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")
@@ -108,9 +98,8 @@ var _ = Describe("BDD of pod-memory-hog experiment", func() {
 
 			//Checking chaosengine verdict
 			By("Checking the Verdict of Chaos Engine")
-			if _, err := pkg.ChaosEngineVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChaosEngine Verdict check failed, due to %v", err)
-			}
+			_, err = pkg.ChaosEngineVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
 
 		})
 	})
@@ -125,27 +114,25 @@ var _ = Describe("BDD of pod-memory-hog experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				log.Fatalf("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
 
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")
 			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
 			environment.GetENV(&testsDetails, "pod-memory-hog", "go-engine10")
 
-			//Updating the pipeline result table
-			By("Updating the pipeline result table")
 			//Getting chaosengine verdict
 			By("Getting Verdict of Chaos Engine")
 			ChaosEngineVerdict, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
-			if err != nil {
-				log.Fatalf("Getting ChaosEngine Verdict failed, due to %v", err)
-			}
+			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+			Expect(ChaosEngineVerdict).NotTo(BeEmpty(), "Fail to get chaos engine verdict, due to {%v}", err)
 
-			if err := pkg.UpdateResultTable("Consume memory resources on the application container", ChaosEngineVerdict, &testsDetails); err != nil {
-				log.Fatalf("Job Result table updation failed, due to %v", err)
-			}
+			//Updating the pipeline result table
+			By("Updating the pipeline result table")
+			err = pkg.UpdateResultTable("Consume memory resources on the application container", ChaosEngineVerdict, &testsDetails)
+			Expect(err).To(BeNil(), "Job Result Updation failed, due to {%v}", err)
+
 		})
 	})
 })

--- a/tests/pod-network-corruption_test.go
+++ b/tests/pod-network-corruption_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"log"
 	"testing"
 
 	"github.com/litmuschaos/litmus-e2e/pkg"
@@ -32,9 +31,8 @@ var _ = Describe("BDD of pod-network-corruption experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				klog.Infof("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
 
 			//Fetching all the default ENV
 			//Note: please don't provide custom experiment name here
@@ -44,46 +42,39 @@ var _ = Describe("BDD of pod-network-corruption experiment", func() {
 
 			// Checking the chaos operator running status
 			By("[Status]: Checking chaos operator status")
-			if err := pkg.OperatorStatusCheck(&testsDetails, clients); err != nil {
-				log.Fatalf("Operator status check failed, due to %v", err)
-			}
+			err = pkg.OperatorStatusCheck(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Operator status check failed, due to {%v}", err)
 
 			//Installing RBAC for the experiment
 			By("[Install]: Installing RBAC")
-			if err := pkg.InstallGoRbac(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install rbac, due to %v", err)
-			}
+			err = pkg.InstallGoRbac(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install rbac, due to {%v}", err)
 
 			//Installing Chaos Experiment for pod-network-corruption
 			By("[Install]: Installing chaos experiment")
-			if err := pkg.InstallGoChaosExperiment(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaos experiment, due to %v", err)
-			}
+			err = pkg.InstallGoChaosExperiment(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos experiment, due to {%v}", err)
 
 			//Installing Chaos Engine for pod-network-corruption
 			By("[Install]: Installing chaos engine")
-			if err := pkg.InstallGoChaosEngine(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaosengine, due to %v", err)
-			}
+			err = pkg.InstallGoChaosEngine(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaosengine, due to {%v}", err)
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			if _, err := pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Runner pod status check failed, due to %v", err)
-			}
+			_, err = pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Waiting for experiment job to get completed
 			//And Print the logs of the job pod (chaos pod)
 			By("[Status]: Wait for job completion and then print logs")
-			if _, err := pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Fail to get the experiment job pod logs, due to %v", err)
-			}
+			_, err = pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Fail to get the experiment job pod logs, due to {%v}", err)
 
 			//Checking the chaosresult verdict
 			By("[Verdict]: Checking the chaosresult verdict")
-			if _, err := pkg.ChaosResultVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChasoResult Verdict check failed, due to %v", err)
-			}
+			_, err = pkg.ChaosResultVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 
 		})
 	})
@@ -97,9 +88,8 @@ var _ = Describe("BDD of pod-network-corruption experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				log.Fatalf("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
 
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")
@@ -108,9 +98,8 @@ var _ = Describe("BDD of pod-network-corruption experiment", func() {
 
 			//Checking chaosengine verdict
 			By("Checking the Verdict of Chaos Engine")
-			if _, err := pkg.ChaosEngineVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChaosEngine Verdict check failed, due to %v", err)
-			}
+			_, err = pkg.ChaosEngineVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
 
 		})
 	})
@@ -125,9 +114,8 @@ var _ = Describe("BDD of pod-network-corruption experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				log.Fatalf("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
 
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")
@@ -139,13 +127,12 @@ var _ = Describe("BDD of pod-network-corruption experiment", func() {
 			//Getting chaosengine verdict
 			By("Getting Verdict of Chaos Engine")
 			ChaosEngineVerdict, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
-			if err != nil {
-				log.Fatalf("Getting ChaosEngine Verdict failed, due to %v", err)
-			}
+			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+			Expect(ChaosEngineVerdict).NotTo(BeEmpty(), "Fail to get chaos engine verdict, due to {%v}", err)
 
-			if err := pkg.UpdateResultTable("Inject Network Packet Corruption Into Application Pod", ChaosEngineVerdict, &testsDetails); err != nil {
-				log.Fatalf("Job Result table updation failed, due to %v", err)
-			}
+			err = pkg.UpdateResultTable("Inject Network Packet Corruption Into Application Pod", ChaosEngineVerdict, &testsDetails)
+			Expect(err).To(BeNil(), "Job Result Updation failed, due to {%v}", err)
+
 		})
 	})
 })

--- a/tests/pod-network-duplication_test.go
+++ b/tests/pod-network-duplication_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"log"
 	"testing"
 
 	"github.com/litmuschaos/litmus-e2e/pkg"
@@ -32,9 +31,8 @@ var _ = Describe("BDD of pod-network-duplication experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				klog.Infof("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
 
 			//Fetching all the default ENV
 			//Note: please don't provide custom experiment name here
@@ -44,46 +42,39 @@ var _ = Describe("BDD of pod-network-duplication experiment", func() {
 
 			// Checking the chaos operator running status
 			By("[Status]: Checking chaos operator status")
-			if err := pkg.OperatorStatusCheck(&testsDetails, clients); err != nil {
-				log.Fatalf("Operator status check failed, due to %v", err)
-			}
+			err = pkg.OperatorStatusCheck(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Operator status check failed, due to {%v}", err)
 
 			//Installing RBAC for the experiment
 			By("[Install]: Installing RBAC")
-			if err := pkg.InstallGoRbac(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install rbac, due to %v", err)
-			}
+			err = pkg.InstallGoRbac(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install rbac, due to {%v}", err)
 
 			//Installing Chaos Experiment for pod-network-duplication
 			By("[Install]: Installing chaos experiment")
-			if err := pkg.InstallGoChaosExperiment(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaos experiment, due to %v", err)
-			}
+			err = pkg.InstallGoChaosExperiment(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos experiment, due to {%v}", err)
 
 			//Installing Chaos Engine for pod-network-duplication
 			By("[Install]: Installing chaos engine")
-			if err := pkg.InstallGoChaosEngine(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaosengine, due to %v", err)
-			}
+			err = pkg.InstallGoChaosEngine(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaosengine, due to {%v}", err)
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			if _, err := pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Runner pod status check failed, due to %v", err)
-			}
+			_, err = pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Waiting for experiment job to get completed
 			//And Print the logs of the job pod (chaos pod)
 			By("[Status]: Wait for job completion and then print logs")
-			if _, err := pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Fail to get the experiment job pod logs, due to %v", err)
-			}
+			_, err = pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Fail to get the experiment job pod logs, due to {%v}", err)
 
 			//Checking the chaosresult verdict
 			By("[Verdict]: Checking the chaosresult verdict")
-			if _, err := pkg.ChaosResultVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChasoResult Verdict check failed, due to %v", err)
-			}
+			_, err = pkg.ChaosResultVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 
 		})
 	})
@@ -97,9 +88,8 @@ var _ = Describe("BDD of pod-network-duplication experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				log.Fatalf("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
 
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")
@@ -108,9 +98,8 @@ var _ = Describe("BDD of pod-network-duplication experiment", func() {
 
 			//Checking chaosengine verdict
 			By("Checking the Verdict of Chaos Engine")
-			if _, err := pkg.ChaosEngineVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChaosEngine Verdict check failed, due to %v", err)
-			}
+			_, err = pkg.ChaosEngineVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
 
 		})
 	})
@@ -125,9 +114,8 @@ var _ = Describe("BDD of pod-network-duplication experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				log.Fatalf("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
 
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")
@@ -139,13 +127,12 @@ var _ = Describe("BDD of pod-network-duplication experiment", func() {
 			//Getting chaosengine verdict
 			By("Getting Verdict of Chaos Engine")
 			ChaosEngineVerdict, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
-			if err != nil {
-				log.Fatalf("Getting ChaosEngine Verdict failed, due to %v", err)
-			}
+			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+			Expect(ChaosEngineVerdict).NotTo(BeEmpty(), "Fail to get chaos engine verdict, due to {%v}", err)
 
-			if err := pkg.UpdateResultTable("Injects chaos to disrupt network connectivity of pod", ChaosEngineVerdict, &testsDetails); err != nil {
-				log.Fatalf("Job Result table updation failed, due to %v", err)
-			}
+			err = pkg.UpdateResultTable("Injects chaos to disrupt network connectivity of pod", ChaosEngineVerdict, &testsDetails)
+			Expect(err).To(BeNil(), "Job Result Updation failed, due to {%v}", err)
+
 		})
 	})
 })

--- a/tests/pod-network-latency_test.go
+++ b/tests/pod-network-latency_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"log"
 	"testing"
 
 	"github.com/litmuschaos/litmus-e2e/pkg"
@@ -32,9 +31,8 @@ var _ = Describe("BDD of pod-network-latency experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				klog.Infof("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
 
 			//Fetching all the default ENV
 			//Note: please don't provide custom experiment name here
@@ -44,46 +42,39 @@ var _ = Describe("BDD of pod-network-latency experiment", func() {
 
 			// Checking the chaos operator running status
 			By("[Status]: Checking chaos operator status")
-			if err := pkg.OperatorStatusCheck(&testsDetails, clients); err != nil {
-				log.Fatalf("Operator status check failed, due to %v", err)
-			}
+			err = pkg.OperatorStatusCheck(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Operator status check failed, due to {%v}", err)
 
 			//Installing RBAC for the experiment
 			By("[Install]: Installing RBAC")
-			if err := pkg.InstallGoRbac(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install rbac, due to %v", err)
-			}
+			err = pkg.InstallGoRbac(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install rbac, due to {%v}", err)
 
 			//Installing Chaos Experiment for pod-network-latency
 			By("[Install]: Installing chaos experiment")
-			if err := pkg.InstallGoChaosExperiment(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaos experiment, due to %v", err)
-			}
+			err = pkg.InstallGoChaosExperiment(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos experiment, due to {%v}", err)
 
 			//Installing Chaos Engine for pod-network-latency
 			By("[Install]: Installing chaos engine")
-			if err := pkg.InstallGoChaosEngine(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaosengine, due to %v", err)
-			}
+			err = pkg.InstallGoChaosEngine(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaosengine, due to {%v}", err)
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			if _, err := pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Runner pod status check failed, due to %v", err)
-			}
+			_, err = pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Waiting for experiment job to get completed
 			//And Print the logs of the job pod (chaos pod)
 			By("[Status]: Wait for job completion and then print logs")
-			if _, err := pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Fail to get the experiment job pod logs, due to %v", err)
-			}
+			_, err = pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Fail to get the experiment job pod logs, due to {%v}", err)
 
 			//Checking the chaosresult verdict
 			By("[Verdict]: Checking the chaosresult verdict")
-			if _, err := pkg.ChaosResultVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChasoResult Verdict check failed, due to %v", err)
-			}
+			_, err = pkg.ChaosResultVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 
 		})
 	})
@@ -97,9 +88,8 @@ var _ = Describe("BDD of pod-network-latency experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				log.Fatalf("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
 
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")
@@ -108,9 +98,8 @@ var _ = Describe("BDD of pod-network-latency experiment", func() {
 
 			//Checking chaosengine verdict
 			By("Checking the Verdict of Chaos Engine")
-			if _, err := pkg.ChaosEngineVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChaosEngine Verdict check failed, due to %v", err)
-			}
+			_, err = pkg.ChaosEngineVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
 
 		})
 	})
@@ -125,9 +114,8 @@ var _ = Describe("BDD of pod-network-latency experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				log.Fatalf("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
 
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")
@@ -139,13 +127,12 @@ var _ = Describe("BDD of pod-network-latency experiment", func() {
 			//Getting chaosengine verdict
 			By("Getting Verdict of Chaos Engine")
 			ChaosEngineVerdict, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
-			if err != nil {
-				log.Fatalf("Getting ChaosEngine Verdict failed, due to %v", err)
-			}
+			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+			Expect(ChaosEngineVerdict).NotTo(BeEmpty(), "Fail to get chaos engine verdict, due to {%v}", err)
 
-			if err := pkg.UpdateResultTable("Inject Network Latency Into Application Pod", ChaosEngineVerdict, &testsDetails); err != nil {
-				log.Fatalf("Job Result table updation failed, due to %v", err)
-			}
+			err = pkg.UpdateResultTable("Inject Network Latency Into Application Pod", ChaosEngineVerdict, &testsDetails)
+			Expect(err).To(BeNil(), "Job Result Updation failed, due to {%v}", err)
+
 		})
 	})
 })

--- a/tests/pod-network-loss_test.go
+++ b/tests/pod-network-loss_test.go
@@ -29,12 +29,10 @@ var _ = Describe("BDD of pod-network-loss experiment", func() {
 
 			testsDetails := types.TestDetails{}
 			clients := environment.ClientSets{}
-
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				klog.Infof("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
 
 			//Fetching all the default ENV
 			//Note: please don't provide custom experiment name here
@@ -44,46 +42,39 @@ var _ = Describe("BDD of pod-network-loss experiment", func() {
 
 			// Checking the chaos operator running status
 			By("[Status]: Checking chaos operator status")
-			if err := pkg.OperatorStatusCheck(&testsDetails, clients); err != nil {
-				log.Fatalf("Operator status check failed, due to %v", err)
-			}
+			err = pkg.OperatorStatusCheck(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Operator status check failed, due to {%v}", err)
 
 			//Installing RBAC for the experiment
 			By("[Install]: Installing RBAC")
-			if err := pkg.InstallGoRbac(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install rbac, due to %v", err)
-			}
+			err = pkg.InstallGoRbac(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install rbac, due to {%v}", err)
 
 			//Installing Chaos Experiment for pod-network-loss
 			By("[Install]: Installing chaos experiment")
-			if err := pkg.InstallGoChaosExperiment(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaos experiment, due to %v", err)
-			}
+			err = pkg.InstallGoChaosExperiment(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos experiment, due to {%v}", err)
 
 			//Installing Chaos Engine for pod-network-loss
 			By("[Install]: Installing chaos engine")
-			if err := pkg.InstallGoChaosEngine(&testsDetails, testsDetails.ChaosNamespace); err != nil {
-				log.Fatalf("Fail to install chaosengine, due to %v", err)
-			}
+			err = pkg.InstallGoChaosEngine(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaosengine, due to {%v}", err)
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			if _, err := pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Runner pod status check failed, due to %v", err)
-			}
+			_, err = pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Waiting for experiment job to get completed
 			//And Print the logs of the job pod (chaos pod)
 			By("[Status]: Wait for job completion and then print logs")
-			if _, err := pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients); err != nil {
-				log.Fatalf("Fail to get the experiment job pod logs, due to %v", err)
-			}
+			_, err = pkg.JobLogs(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Fail to get the experiment job pod logs, due to {%v}", err)
 
 			//Checking the chaosresult verdict
 			By("[Verdict]: Checking the chaosresult verdict")
-			if _, err := pkg.ChaosResultVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChasoResult Verdict check failed, due to %v", err)
-			}
+			_, err = pkg.ChaosResultVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 
 		})
 	})
@@ -97,9 +88,8 @@ var _ = Describe("BDD of pod-network-loss experiment", func() {
 
 			//Getting kubeConfig and Generate ClientSets
 			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				log.Fatalf("Unable to Get the kubeconfig due to %v", err)
-			}
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
 
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")
@@ -108,9 +98,8 @@ var _ = Describe("BDD of pod-network-loss experiment", func() {
 
 			//Checking chaosengine verdict
 			By("Checking the Verdict of Chaos Engine")
-			if _, err := pkg.ChaosEngineVerdict(&testsDetails, clients); err != nil {
-				log.Fatalf("ChaosEngine Verdict check failed, due to %v", err)
-			}
+			_, err = pkg.ChaosEngineVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
 
 		})
 	})
@@ -139,13 +128,12 @@ var _ = Describe("BDD of pod-network-loss experiment", func() {
 			//Getting chaosengine verdict
 			By("Getting Verdict of Chaos Engine")
 			ChaosEngineVerdict, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
-			if err != nil {
-				log.Fatalf("Getting ChaosEngine Verdict failed, due to %v", err)
-			}
+			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+			Expect(ChaosEngineVerdict).NotTo(BeEmpty(), "Fail to get chaos engine verdict, due to {%v}", err)
 
-			if err := pkg.UpdateResultTable("Inject Packet Loss Into Application Pod", ChaosEngineVerdict, &testsDetails); err != nil {
-				log.Fatalf("Job Result table updation failed, due to %v", err)
-			}
+			err = pkg.UpdateResultTable("Inject Packet Loss Into Application Pod", ChaosEngineVerdict, &testsDetails)
+			Expect(err).To(BeNil(), "Job Result Updation failed, due to {%v}", err)
+
 		})
 	})
 })

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -34,6 +34,8 @@ github.com/golang/protobuf/ptypes
 github.com/golang/protobuf/ptypes/any
 github.com/golang/protobuf/ptypes/duration
 github.com/golang/protobuf/ptypes/timestamp
+# github.com/google/btree v1.0.0
+## explicit
 # github.com/google/gofuzz v1.1.0
 ## explicit
 github.com/google/gofuzz


### PR DESCRIPTION
Signed-off-by: Udit Gaurav <udit.gaurav@mayadata.io>

**Why do we need this PR?**

- This Pull Request converts all `log.Fatalf `as it does `Exit 1` in case of failure and quits the execution of Bdds, So all the Bdds will not run. We need to change it to genko `Except` so that in case of failure also the execution of Bdds does not hinder. 