### PR TITLE
chore(new_test): Add Readme and result table in website for new tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,9 @@ This repository contains the Litmus E2E pipelines for testing the chaos and litm
   </tr>
 </table>
 
-## How to view the details of the last few pipeline runs?
-To view the details of the last few pipelines runs:
-- Choose the above directory whose pipeline details you want.
-- Inside it contains the details of the job in each folder and pipeline details in README.md. 
+## Pipeline Execution Details
+
+Visit [LitmusChaos CI](https://litmuschaos.github.io/litmus-e2e) to get the pipeline execution details.
 
 # Generic E2E Pipeline:
 

--- a/generic-pipeline/admin-mode/README.md
+++ b/generic-pipeline/admin-mode/README.md
@@ -1,0 +1,20 @@
+# Admin Mode Test
+
+## Test Metadata
+<table>
+    <tr>
+        <th> Name </th>
+        <th> Description </th>
+        <th> Category <br>(Type) </th>
+        <th> Docs </th>
+    </tr>
+    <tr>
+        <td> Admin Mode Test </td>
+        <td> It is used to test the operator admin mode functionality. Admin mode is one of the ways the chaos orchestration is set up in Litmus, wherein all chaos resources (i.e., install time resources like the operator, chaosexperiment CRs, chaosServiceAccount/rbac and runtime resources like chaosengine, chaos-runner, experiment jobs & chaosresults) are setup in a single admin namespace (typically, litmus) </td>
+        <td> Operator <br>(Positive) </td>
+        <td>  <a href="https://docs.litmuschaos.io/docs/next/admin-mode/#what-is-adminstator-mode"> Here </a> </td>
+    </tr>
+ </table>
+
+### Pipeline Runs
+ 

--- a/generic-pipeline/annotation-check/README.md
+++ b/generic-pipeline/annotation-check/README.md
@@ -1,0 +1,20 @@
+# Annotation Check Test
+
+## Test Metadata
+<table>
+    <tr>
+        <th> Name </th>
+        <th> Description </th>
+        <th> Category <br>(Type) </th>
+        <th> Docs </th>
+    </tr>
+    <tr>
+        <td> Annotation Check Test </td>
+        <td> This is used to test the annotation check flag that controls annotation checks on applications as prerequisites for chaos. When the application is not created then the runner pod will not get created. </td>
+        <td> Engine <br> (Negative) </td>
+        <td>  <a href="https://docs.litmuschaos.io/docs/next/chaosengine/#runtime-specification"> Here </a> </td>
+    </tr>
+ </table>
+
+### Pipeline Runs
+ 

--- a/generic-pipeline/appinfo/README.md
+++ b/generic-pipeline/appinfo/README.md
@@ -1,0 +1,20 @@
+# AppInfo Check Test
+
+## Test Metadata
+<table>
+    <tr>
+        <th> Name </th>
+        <th> Description </th>
+        <th> Category <br>(Type) </th>
+        <th> Docs </th>
+    </tr>
+    <tr>
+        <td> AppInfo Test </td>
+        <td> This is used to test the app info flag that specifies the application for chaos. When a wrong appinfo is given along with annotation check false then the chaosengine and chaosresult verdict are expected to be Fail. </td>
+        <td> Engine <br> (Negative) </td>
+        <td>  <a href="https://docs.litmuschaos.io/docs/next/chaosengine/#application-specification"> Here </a> </td>
+    </tr>
+ </table>
+
+### Pipeline Runs
+ 

--- a/generic-pipeline/engine-state/README.md
+++ b/generic-pipeline/engine-state/README.md
@@ -1,0 +1,20 @@
+# Engine State Test
+
+## Test Metadata
+<table>
+    <tr>
+        <th> Name </th>
+        <th> Description </th>
+        <th> Category <br>(Type) </th>
+        <th> Docs </th>
+    </tr>
+    <tr>
+        <td> Engine State Test </td>
+        <td> Engine State test or Abort Chaos test is used to test if the chaos experiment gets aborted when the engine state is set to stop or not along with ChaosEngine and ChaosResult Verdict as Stopped. All chaos resources will be cleanup when the chaos is aborted.</td>
+        <td> Engine <br> (Negative) </td>
+        <td>  <a href="https://docs.litmuschaos.io/docs/next/chaosengine/#state-specification"> Here </a> </td>
+    </tr>
+ </table>
+
+### Pipeline Runs
+ 

--- a/generic-pipeline/experiment-404/README.md
+++ b/generic-pipeline/experiment-404/README.md
@@ -1,0 +1,20 @@
+# Experiment 404 Test
+
+## Test Metadata
+<table>
+    <tr>
+        <th> Name </th>
+        <th> Description </th>
+        <th> Category <br>(Type) </th>
+        <th> Docs </th>
+    </tr>
+    <tr>
+        <td> Experiment 404 </td>
+        <td> Experiment 404 tests the chaos with wrong/invalid experiment name in chaos engine. In such cases the runner pod will not be able to create the chaos pod and so the chaos result. The chaos engine verdict will be Fail </td>
+        <td> Engine <br> (Negative) </td>
+        <td>  <a href="https://docs.litmuschaos.io/docs/next/chaosengine/#experiment-specification"> Here </a> </td>
+    </tr>
+ </table>
+
+### Pipeline Runs
+ 

--- a/generic-pipeline/experiment-image/README.md
+++ b/generic-pipeline/experiment-image/README.md
@@ -1,0 +1,18 @@
+# Experiment Image Test
+
+## Test Metadata
+<table>
+    <tr>
+        <th> Name </th>
+        <th> Description </th>
+        <th> Category <br>(Type) </th>
+    </tr>
+    <tr>
+        <td> Experiment Image </td>
+        <td> Experiment Image test is use to test the execution of the experiment in case of wrong experiment image name in chaos experiment spec. In such a case no chaos pod and chaos result will be created and the chaos engine verdict will remain Awaited. </td>
+        <td> Experiment <br>(Negative) </td>
+    </tr>
+ </table>
+
+### Pipeline Runs
+ 

--- a/generic-pipeline/generic.md
+++ b/generic-pipeline/generic.md
@@ -26,6 +26,8 @@ filename: generic
 
 # **Pipeline Jobs**
 
+### **Experiment Tests**
+
 - [TCID-VMWx-GENERIC-APP-POD-DELETE](https://github.com/litmuschaos/litmus-e2e/blob/master/generic-pipeline/pod-delete/README.md)
 - [TCID-VMWx-GENERIC-APP-CONTAINER-KILL](https://github.com/litmuschaos/litmus-e2e/blob/master/generic-pipeline/container-kill/README.md)
 - [TCID-VMWx-GENERIC-APP-POD-CPU-HOG](https://github.com/litmuschaos/litmus-e2e/blob/master/generic-pipeline/pod-cpu-hog/README.md)
@@ -40,9 +42,23 @@ filename: generic
 - [TCID-VMWx-GENERIC-INFRA-NODE-MEMORY-HOG](https://github.com/litmuschaos/litmus-e2e/blob/master/generic-pipeline/node-memory-hog/README.md)
 - [TCID-VMWx-GENERIC-INFRA-NODE-DRAIN](https://github.com/litmuschaos/litmus-e2e/blob/master/generic-pipeline/node-drain/README.md)
 - [TCID-VMWx-GENERIC-INFRA-KUBELET-SERVICE-KILL](https://github.com/litmuschaos/litmus-e2e/blob/master/generic-pipeline/kubelet-service-kill/README.md)
-- [TCID-VMWx-GENERIC-INFRA-NODE-TAINT](https://github.com/litmuschaos/litmus-e2e/tree/master/generic-pipeline/node-taint)
-- [TCID-VMWx-GENERIC-CONTROL-OPERATOR-RECONCILE-RESILIENCY]()
-- [TCID-VMWx-GENERIC-CONTROL-ADMIN-MODE]()
+- [TCID-VMWx-GENERIC-INFRA-NODE-TAINT](https://github.com/litmuschaos/litmus-e2e/tree/master/generic-pipeline/node-taint/README.md)
+
+- [TCID-VMWx-GENERIC-EXPERIMENT-EXPERIMENT-IMAGE-NAME](https://github.com/litmuschaos/litmus-e2e/blob/master/generic-pipeline/experiment-image/README.md)
+
+### **Operator Tests**
+
+- [TCID-VMWx-GENERIC-OPERATOR-RECONCILE-RESILIENCY](https://github.com/litmuschaos/litmus-e2e/blob/master/generic-pipeline/reconcile-resiliency/README.md)
+- [TCID-VMWx-GENERIC-OPERATOR-ADMIN-MODE](https://github.com/litmuschaos/litmus-e2e/blob/master/generic-pipeline/admin-mode/README.md)
+
+### **Engine Tests**
+
+- [TCID-VMWx-GENERIC-ENGINE-ANNOTATION-CHECK](https://github.com/litmuschaos/litmus-e2e/blob/master/generic-pipeline/annotation-check/README.md)
+- [TCID-VMWx-GENERIC-ENGINE-APP-INFO](https://github.com/litmuschaos/litmus-e2e/blob/master/generic-pipeline/appinfo/README.md)
+- [TCID-VMWx-GENERIC-ENGINE-ENGINE-STATE](https://github.com/litmuschaos/litmus-e2e/blob/master/generic-pipeline/engine-state/README.md)
+- [TCID-VMWx-GENERIC-ENGINE-EXPERIMENT-NAME](https://github.com/litmuschaos/litmus-e2e/blob/master/generic-pipeline/experiment-404/README.md)
+- [TCID-VMWx-GENERIC-ENGINE-JOB-CLEANUP-POLICY](https://github.com/litmuschaos/litmus-e2e/blob/master/generic-pipeline/job-cleanup-policy/README.md)
+- [TCID-VMWx-GENERIC-ENGINE-SERVICE-ACCOUNT](https://github.com/litmuschaos/litmus-e2e/blob/master/generic-pipeline/service-account/README.md)
 
 # **Pipeline Runs**
 

--- a/generic-pipeline/job-cleanup-policy/README.md
+++ b/generic-pipeline/job-cleanup-policy/README.md
@@ -1,0 +1,18 @@
+# Job Cleanup Policy Test
+
+## Test Metadata
+<table>
+    <tr>
+        <th> Name </th>
+        <th> Description </th>
+        <th> Category <br>(Type) </th>
+    </tr>
+    <tr>
+        <td> Job Cleanup Policy Test </td>
+        <td> In this we test the job cleanup policy flag that control the cleanup of chaos experiment job post execution of chaos. When it is set to retain the chaos pod retains after chaos and when set to delete the chaos pod gets removed after chaos. </td>
+        <td> Engine <br>(Positive) </td>
+    </tr>
+ </table>
+
+### Pipeline Runs
+ 

--- a/generic-pipeline/reconcile-resiliency/README.md
+++ b/generic-pipeline/reconcile-resiliency/README.md
@@ -1,0 +1,18 @@
+# Reconsile Resiliency Test
+
+## Test Metadata
+<table>
+    <tr>
+        <th> Name </th>
+        <th> Description </th>
+        <th> Category <br>(Type) </th>
+    </tr>
+    <tr>
+        <td> Reconsile Resiliency Test </td>
+        <td> It is used to test the operator reconsile resiliency that is check for more than one chaos in different namespaces at same time.  </td>
+        <td> Operator <br>(Positive) </td>
+    </tr>
+ </table>
+
+### Pipeline Runs
+ 

--- a/generic-pipeline/service-account/README.md
+++ b/generic-pipeline/service-account/README.md
@@ -1,0 +1,18 @@
+# Service Account Test
+
+## Test Metadata
+<table>
+    <tr>
+        <th> Name </th>
+        <th> Description </th>
+        <th> Category <br>(Type) </th>
+    </tr>
+    <tr>
+        <td> Service Account Test </td>
+        <td>In this test a wrong/dummy service account name is provided in the engine spec which results in unable to create the runner pod, chaos pod and chaos result. The experiment list in chaos engine remains empty in such a case. </td>
+        <td> Engine <br> (Negative) </td>
+    </tr>
+ </table>
+
+### Pipeline Runs
+ 


### PR DESCRIPTION
Signed-off-by: Udit Gaurav <udit.gaurav@mayadata.io>

Issue:
- resolved: - https://github.com/litmuschaos/litmus/issues/1923

**_This PR includes:_**

- Readme (docs) for new engine and experiment spec test.
- Updating the Readme for operator tests.
- Updating the [web site](https://litmuschaos.github.io/litmus-e2e) with new tests.