### PR TITLE
(Minor-Change):Removed dotenv from gitlab-ci.yml.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,8 +42,6 @@ Portal-Setup:
     when: always
     paths:
       - .kube/
-    reports:
-      dotenv: Portal-Setup.env
   cache: {}
 
 Cypress-Setup:
@@ -69,8 +67,6 @@ PreTest-Setup:
     when: always
     paths:
       - CypressE2E/cypress/screenshots
-  dependencies:
-    - Portal-Setup
   cache:
     <<: *global_cache
     policy: pull
@@ -88,8 +84,6 @@ PreTest-Setup:
     when: always
     paths:
       - CypressE2E/cypress/screenshots
-  dependencies:
-    - Portal-Setup
   cache:
     <<: *global_cache
     policy: pull


### PR DESCRIPTION
**This PR will remove reports:dotenv from gitlab-ci.yml (not required anymore).**

Pipeline Test: https://gitlab.com/Jonsy13/litmus-e2e/-/pipelines/201993788