### PR TITLE
chore(new_test): Add without appinfo test for Node level experiment and some refactoring

### DIFF
--- a/.master-plan.yml
+++ b/.master-plan.yml
@@ -104,7 +104,16 @@ spec:
       test/feature: "Generic-App"
       test/tags: "pod, io, stress"
       git/location: "https://github.com/litmuschaos/litmus-e2e/tree/master/generic-pipeline/pod-io-stress"
-      test/status: "Done"        
+      test/status: "Done"    
+      
+  - tcid: TCID-VMWx-GENERIC-INFRA-WITHOUT-APP-INFO
+    name: "TCID-VMWx-GENERIC-INFRA-WITHOUT-APP-INFO"
+    description: "Test the experiment without providing appinfo"
+    labels:
+      test/feature: "Generic-App"
+      test/tags: "pod, appinfo"
+      git/location: ""
+      test/status: "Done"       
 
   # ----------------------------------------------------------
   # Kubernetes Infra level chaos experiment BDDs

--- a/Makefile
+++ b/Makefile
@@ -3,82 +3,34 @@
 
 IS_DOCKER_INSTALLED = $(shell which docker >> /dev/null 2>&1; echo $$?)
 
-# export all the dependent variables
-EXPORT_VARIABLES = $(shell echo "export CI_JOB_ID=${CI_JOB_ID} && export CI_PIPELINE_ID=${CI_PIPELINE_ID} && export GITHUB_TOKEN=${GITHUB_TOKEN} && \
-export CGO_ENABLED=${CGO_ENABLED} && export ANSIBLE_EXPERIMENT_IMAGE=${ANSIBLE_EXPERIMENT_IMAGE} && export GO_EXPERIMENT_IMAGE=${GO_EXPERIMENT_IMAGE} && \
-export OPERATOR_IMAGE=${OPERATOR_IMAGE} && export RUNNER_IMAGE=${RUNNER_IMAGE} && export OPERATOR_NAME=${OPERATOR_NAME} && export CHAOS_NAMESPACE=${CHAOS_NAMESPACE} && \
-export APP_NS=${APP_NS} && export APP_LABEL=${APP_LABEL} && export JOB_CLEANUP_POLICY=${JOB_CLEANUP_POLICY} && export ANNOTATION_CHECK=${ANNOTATION_CHECK} && \
-export APPLICATION_NODE_NAME=${APPLICATION_NODE_NAME} && export IMAGE_PULL_POLICY=${IMAGE_PULL_POLICY} && export TOTAL_CHAOS_DURATION=${TOTAL_CHAOS_DURATION} && \
-export RBAC_PATH=${RBAC_PATH} && export EXPERIMENT_PATH=${EXPERIMENT_PATH} && export ENGINE_PATH=${ENGINE_PATH} && export ANSIBLE_RBAC_PATH=${ANSIBLE_RBAC_PATH} && \
-export ANSIBLE_EXPERIMENT_PATH=${ANSIBLE_EXPERIMENT_PATH} && export ANSIBLE_ENGINE_PATH=${ANSIBLE_ENGINE_PATH} && export INSTALL_LITMUS=${INSTALL_LITMUS} && export ADMIN_RBAC_PATH=${ADMIN_RBAC_PATH}")
-
 # docker info
 DOCKER_REPO ?= litmuschaos
 DOCKER_IMAGE ?= litmus-e2e
 DOCKER_TAG ?= ci
 
-TESTPATH ?= /home/udit/go/src/github.com/litmuschaos/litmus-e2e
-
-
 .PHONY: build-litmus
 build-litmus:
 
-	@echo "------------"
-	@echo "Build Litmus"
-	@echo "------------"
-	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
-	 "$(EXPORT_VARIABLES) && go test $(TESTPATH)/tests/install-litmus_test.go -v -count=1"
-
-.PHONY: build-litmus
-build-litmus:
-
-	@echo "-------------------------------------"
-	@echo "Build Litmus For Pod Level Chaos test"
-	@echo "-------------------------------------"
+	@echo "----------------"
+	@echo "Building Litmus "
+	@echo "----------------"
 	@go test tests/install-litmus_test.go -v -count=1
 
 .PHONY: app-deploy
 app-deploy:
 
-	@echo "---------------------"
-	@echo "Deploying Application"
-	@echo "---------------------"
-	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
-	 "$(EXPORT_VARIABLES)  && go test $(TESTPATH)/tests/app-deploy_test.go -v -count=1"
-
-.PHONY: app-deploy
-app-deploy:
-
-	@echo "----------------------------------------"
-	@echo "Deploying Application For pod level test"
-	@echo "----------------------------------------"
+	@echo "----------------------"
+	@echo "Deploying Application "
+	@echo "----------------------"
 	@go test tests/app-deploy_test.go -v -count=1
 
 .PHONY: liveness
 liveness:
 
-	@echo "---------------------"
-	@echo "Deploying Application"
-	@echo "---------------------"
-	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
-     "$(EXPORT_VARIABLES)  && go test $(TESTPATH)/tests/app-liveness_test.go -v -count=1"
-
-.PHONY: liveness
-liveness:
-
-	@echo "----------------------------------------"
-	@echo "Deploying Application For Pod level test"
-	@echo "----------------------------------------"
+	@echo "----------------------"
+	@echo "Deploying Liveness Pod"
+	@echo "----------------------"
 	@go test tests/app-liveness_test.go -v -count=1
-
-.PHONY: auxiliary-app
-auxiliary-app:
-
-	@echo "-----------------------"
-	@echo "Deploying Auxiliary App"
-	@echo "-----------------------"
-	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
-	 "$(EXPORT_VARIABLES)  && go test $(TESTPATH)/tests/auxiliary-app_test.go -v -count=1"
 
 .PHONY: auxiliary-app
 auxiliary-app:
@@ -143,8 +95,7 @@ node-cpu-hog:
 	@echo "-------------------------------"
 	@echo "Running node-cpu-hog experiment"
 	@echo "--------------------------------"
-	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
-	"$(EXPORT_VARIABLES)  && go test $(TESTPATH)/tests/node-cpu-hog_test.go -v -count=1"
+	@go test tests/node-cpu-hog_test.go -v -count=1
 
 .PHONY: node-drain
 node-drain:
@@ -152,8 +103,7 @@ node-drain:
 	@echo "---------------------------------"
 	@echo "Running node-drain experiment"
 	@echo "---------------------------------"
-	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
-	"$(EXPORT_VARIABLES)  && go test $(TESTPATH)/tests/node-drain_test.go -v -count=1"
+	@go test tests/node-drain_test.go -v -count=1
 
 .PHONY: disk-fill
 disk-fill:
@@ -169,8 +119,7 @@ node-memory-hog:
 	@echo "----------------------------------"
 	@echo "Running node-memory-hog experiment"
 	@echo "----------------------------------"
-	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
-	"$(EXPORT_VARIABLES)  && go test $(TESTPATH)/tests/node-memory-hog_test.go -v -count=1"
+	@go test tests/node-memory-hog_test.go -v -count=1
 
 .PHONY: pod-memory-hog
 pod-memory-hog:
@@ -186,8 +135,7 @@ kubelet-service-kill:
 	@echo "---------------------------------------"
 	@echo "Running kubelet-service-kill experiment"
 	@echo "---------------------------------------"
-	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
-	"$(EXPORT_VARIABLES)  && go test $(TESTPATH)/tests/kubelet-service-kill_test.go -v -count=1"
+	@go test tests/kubelet-service-kill_test.go -v -count=1
 
 .PHONY: node-taint
 node-taint:
@@ -195,8 +143,7 @@ node-taint:
 	@echo "---------------------------------------"
 	@echo "Running node-taint experiment"
 	@echo "---------------------------------------"
-	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
-	"$(EXPORT_VARIABLES)  && go test $(TESTPATH)/tests/node-taint_test.go -v -count=1"
+	@go test tests/node-taint_test.go -v -count=1
 
 .PHONY: pod-network-duplication
 pod-network-duplication:
@@ -212,8 +159,7 @@ pod-autoscaler:
 	@echo "------------------------------------------"
 	@echo "Running pod-autoscaler experiment"
 	@echo "------------------------------------------"
-	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
-	"$(EXPORT_VARIABLES)  && go test $(TESTPATH)/tests/pod-autoscaler_test.go -v -count=1"	
+	@go test tests/pod-autoscaler_test.go -v -count=1	
 	
 .PHONY: pod-io-stress
 pod-io-stress:
@@ -229,8 +175,7 @@ node-io-stress:
 	@echo "------------------------------------------"
 	@echo "Running node-io-stress experiment"
 	@echo "------------------------------------------"
-	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
-	"$(EXPORT_VARIABLES)  && go test $(TESTPATH)/tests/node-io-stress_test.go -v -count=1"		
+	@go test tests/node-io-stress_test.go -v -count=1		
 
 .PHONY: operator-reconcile-resiliency-check
  operator-reconcile-resiliency-check:
@@ -248,30 +193,26 @@ admin-mode-check:
 	@echo "------------------------"
 	@go test operator/admin-mode_test.go -v -count=1	
 
-
-.PHONY: e2e-metrics
-e2e-metrics:
-
-	@echo "----------------------------"
-	@echo "Pipeline Coverage Percentage"
-	@echo "----------------------------"
-	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
-	 "$(EXPORT_VARIABLES) && cd $(TESTPATH) && bash metrics/e2e-metrics"
+.PHONY: without-app-info
+without-app-info:
+	@echo "-----------------------------"
+	@echo "Running Without App info test"
+	@echo "-----------------------------"
+	@go test tests/without-appinfo_test.go -v -count=1		
 
 .PHONY: app-cleanup
 app-cleanup:
 
 	@echo "--------------------"
-	@echo "Deleting litmus"
+	@echo "Deleting Application "
 	@echo "--------------------"
-	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
-	 "$(EXPORT_VARIABLES)  && go test $(TESTPATH)/tests/litmus-cleanup_test.go -v -count=1"
+	@go test tests/app-cleanup_test.go -v -count=1
 
-.PHONY: app-cleanup
-app-cleanup:
+.PHONY: litmus-cleanup
+litmus-cleanup:
 
 	@echo "--------------------"
-	@echo "Deleting litmus From Cluster 1"
+	@echo "Deleting litmus "
 	@echo "--------------------"
 	@go test tests/litmus-cleanup_test.go -v -count=1
 
@@ -281,8 +222,7 @@ pipeline-status-update:
 	@echo "------------------------"
 	@echo "Updating Pipeline Status"
 	@echo "------------------------"
-	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
-	 "$(EXPORT_VARIABLES)  && go test $(TESTPATH)/tests/pipeline-update_test.go -v -count=1"
+	@go test tests/pipeline-update_test.go -v -count=1
 
 .PHONY: deps
 deps: _build_check_docker godeps docker-build
@@ -350,8 +290,7 @@ ansible-node-cpu-hog:
 	@echo "---------------------------------------"
 	@echo "Running Ansible Node CPU Hog Experiment"
 	@echo "---------------------------------------"
-	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
-	 "$(EXPORT_VARIABLES)  && go test $(TESTPATH)/ansible/ansible-node-cpu-hog_test.go -v -count=1"
+	@go test ansible/ansible-node-cpu-hog_test.go -v -count=1
 
 .PHONY: ansible-node-memory-hog
 ansible-node-memory-hog:
@@ -359,8 +298,7 @@ ansible-node-memory-hog:
 	@echo "------------------------------------------"
 	@echo "Running Ansible Node Memory Hog Experiment"
 	@echo "------------------------------------------"
-	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
-	 "$(EXPORT_VARIABLES)  && go test $(TESTPATH)/ansible/ansible-node-memory-hog_test.go -v -count=1"
+	@ansible/ansible-node-memory-hog_test.go -v -count=1
 
 .PHONY: ansible-pod-cpu-hog
 ansible-pod-cpu-hog:
@@ -410,8 +348,7 @@ ansible-kubelet-service-kill:
 	@echo "-----------------------------------------------"
 	@echo "Running Ansible Kubelet Service Kill Experiment"
 	@echo "-----------------------------------------------"
-	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
-	 "$(EXPORT_VARIABLES)  && go test $(TESTPATH)/ansible/ansible-kubelet-service-kill_test.go -v -count=1"
+	@go test ansible/ansible-kubelet-service-kill_test.go -v -count=1
 
 
 .PHONY: ansible-node-drain
@@ -420,8 +357,7 @@ ansible-node-drain:
 	@echo "-------------------------------------"
 	@echo "Running Ansible Node Drain Experiment"
 	@echo "-------------------------------------"
-	@sshpass -p ${litmus_pass} ssh -o StrictHostKeyChecking=no ${litmus_user}@${litmus_ip} -p ${port} -tt \
-	 "$(EXPORT_VARIABLES)  && go test $(TESTPATH)/ansible/ansible-node-drain_test.go -v -count=1"	
+	@go test ansible/ansible-node-drain_test.go -v -count=1	
 
 ######################
 ### NEGATIVE TESTS ###

--- a/manifest/without_appinfo/kubelet-service-kill.yml
+++ b/manifest/without_appinfo/kubelet-service-kill.yml
@@ -1,0 +1,25 @@
+---
+apiVersion: litmuschaos.io/v1alpha1
+kind: ChaosEngine
+metadata:
+  name: nginx-chaos
+  namespace: default
+spec:
+  annotationCheck: 'false'
+  engineState: 'active'
+  auxiliaryAppInfo: ''
+  chaosServiceAccount: kubelet-service-kill-sa
+  monitoring: false
+  jobCleanUpPolicy: 'delete'
+  experiments:
+    - name: kubelet-service-kill
+      spec:
+        components:
+          nodeSelector: 
+            kubernetes.io/hostname: 'node02'        
+          env:
+            - name: TOTAL_CHAOS_DURATION
+              value: '90' # in seconds
+              
+            - name: TARGET_NODE
+              value: 'node-01'

--- a/manifest/without_appinfo/node-cpu-hog.yml
+++ b/manifest/without_appinfo/node-cpu-hog.yml
@@ -1,0 +1,25 @@
+apiVersion: litmuschaos.io/v1alpha1
+kind: ChaosEngine
+metadata:
+  name: nginx-chaos
+  namespace: default
+spec:
+  annotationCheck: 'false'
+  engineState: 'active'
+  auxiliaryAppInfo: ''
+  chaosServiceAccount: node-cpu-hog-sa
+  monitoring: false
+  jobCleanUpPolicy: 'delete'
+  experiments:
+    - name: node-cpu-hog
+      spec:
+        components:
+          env:
+            - name: TOTAL_CHAOS_DURATION
+              value: '60'
+            
+            - name: NODE_CPU_CORE
+              value: ''
+            
+            - name: TARGET_NODES
+              value: ''

--- a/manifest/without_appinfo/node-drain.yml
+++ b/manifest/without_appinfo/node-drain.yml
@@ -1,0 +1,21 @@
+apiVersion: litmuschaos.io/v1alpha1
+kind: ChaosEngine
+metadata:
+  name: nginx-chaos
+  namespace: default
+spec:
+  annotationCheck: 'false'
+  engineState: 'active'
+  auxiliaryAppInfo: ''
+  chaosServiceAccount: node-drain-sa
+  monitoring: false
+  jobCleanUpPolicy: 'delete'
+  experiments:
+    - name: node-drain
+      spec:
+        components:
+          nodeSelector: 
+            kubernetes.io/hostname: 'node02'        
+          env:
+            - name: TARGET_NODE
+              value: 'node-01'

--- a/manifest/without_appinfo/node-io-stress.yml
+++ b/manifest/without_appinfo/node-io-stress.yml
@@ -1,0 +1,25 @@
+apiVersion: litmuschaos.io/v1alpha1
+kind: ChaosEngine
+metadata:
+  name: nginx-chaos
+  namespace: default
+spec:
+  annotationCheck: 'false'
+  engineState: 'active'
+  auxiliaryAppInfo: ''
+  chaosServiceAccount: node-io-stress-sa
+  monitoring: false
+  jobCleanUpPolicy: 'delete'
+  experiments:
+    - name: node-io-stress
+      spec:
+        components:
+          env:
+            - name: TOTAL_CHAOS_DURATION
+              value: '120'
+
+            - name: FILESYSTEM_UTILIZATION_PERCENTAGE
+              value: '10'
+            
+            - name: TARGET_NODES
+              value: ''

--- a/manifest/without_appinfo/node-memory-hog.yml
+++ b/manifest/without_appinfo/node-memory-hog.yml
@@ -1,0 +1,26 @@
+ 
+apiVersion: litmuschaos.io/v1alpha1
+kind: ChaosEngine
+metadata:
+  name: nginx-chaos
+  namespace: default
+spec:
+  annotationCheck: 'false'
+  engineState: 'active'
+  auxiliaryAppInfo: ''
+  chaosServiceAccount: node-memory-hog-sa
+  monitoring: false
+  jobCleanUpPolicy: 'delete'
+  experiments:
+    - name: node-memory-hog
+      spec:
+        components:
+          env:
+            - name: TOTAL_CHAOS_DURATION
+              value: '120'
+
+            - name: MEMORY_PERCENTAGE
+              value: '90'
+            
+            - name: TARGET_NODES
+              value: ''

--- a/manifest/without_appinfo/node-taint.yml
+++ b/manifest/without_appinfo/node-taint.yml
@@ -1,0 +1,25 @@
+apiVersion: litmuschaos.io/v1alpha1
+kind: ChaosEngine
+metadata:
+  name: nginx-chaos
+  namespace: default
+spec:
+  annotationCheck: 'false'
+  engineState: 'active'
+  auxiliaryAppInfo: ''
+  chaosServiceAccount: node-taint-sa
+  monitoring: false
+  jobCleanUpPolicy: 'delete'
+  experiments:
+    - name: node-taint
+      spec:
+        components:
+          nodeSelector: 
+            kubernetes.io/hostname: 'node02'        
+          env:
+            # set target node name
+            - name: TARGET_NODE
+              value: 'node-01'
+
+            - name: TAINTS
+              value: 'node.kubernetes.io/unreachable:NoExecute'

--- a/manifest/without_appinfo/pod-autoscaler.yml
+++ b/manifest/without_appinfo/pod-autoscaler.yml
@@ -1,0 +1,23 @@
+apiVersion: litmuschaos.io/v1alpha1
+kind: ChaosEngine
+metadata:
+  name: nginx-chaos
+  namespace: default
+spec:
+  annotationCheck: 'false'
+  engineState: 'active'
+  auxiliaryAppInfo: ''
+  chaosServiceAccount: pod-autoscaler-sa
+  monitoring: false
+  jobCleanUpPolicy: 'delete'
+  experiments:
+    - name: pod-autoscaler
+      spec:
+        components:
+          env:
+            - name: TOTAL_CHAOS_DURATION
+              value: '60'
+
+            - name: REPLICA_COUNT
+              value: '5'
+              

--- a/pkg/ansible-install.go
+++ b/pkg/ansible-install.go
@@ -1,0 +1,133 @@
+package pkg
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"time"
+
+	"github.com/litmuschaos/litmus-e2e/pkg/types"
+	"github.com/pkg/errors"
+	"k8s.io/klog"
+)
+
+var (
+	err error
+)
+
+//InstallAnsibleRbac installs and configure rbac for running ansible based chaos
+func InstallAnsibleRbac(testsDetails *types.TestDetails, rbacNamespace string) error {
+
+	//Fetch RBAC file
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	err = DownloadFile(testsDetails.ExperimentName+"-sa.yaml", testsDetails.AnsibleRbacPath)
+	if err != nil {
+		return errors.Errorf("Fail to fetch the rbac file, due to %v", err)
+	}
+	//Modify Namespace field of the RBAC
+	err = EditFile(testsDetails.ExperimentName+"-sa.yaml", "namespace: default", "namespace: "+rbacNamespace)
+	if err != nil {
+		return errors.Errorf("Fail to Modify rbac file, due to %v", err)
+	}
+	//Creating rbac
+	cmd := exec.Command("kubectl", "apply", "-f", testsDetails.ExperimentName+"-sa.yaml", "-n", rbacNamespace)
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err = cmd.Run()
+	if err != nil {
+		klog.Infof(fmt.Sprint(err) + ": " + stderr.String())
+		klog.Infof("Error: %v", err)
+		return errors.Errorf("Fail to create the rbac file, due to {%v}", err)
+	}
+	klog.Infof("[RBAC]: " + out.String())
+	klog.Info("[RBAC]: Rbac installed successfully !!!")
+
+	return nil
+}
+
+//InstallAnsibleChaosExperiment installs the given ansible based chaos experiment
+func InstallAnsibleChaosExperiment(testsDetails *types.TestDetails, experimentNamespace string) error {
+
+	// Fetch Chaos Experiment
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	if err = DownloadFile(testsDetails.ExperimentName+"-exp.yaml", testsDetails.AnsibleExperimentPath); err != nil {
+		return errors.Errorf("Fail to fetch the experiment file, due to %v", err)
+	}
+	// Modify the spec of experiemnt file
+	if err = EditFile(testsDetails.ExperimentName+"-exp.yaml", "image: \"litmuschaos/ansible-runner:latest\"", "image: "+testsDetails.AnsibleExperimentImage); err != nil {
+		return errors.Errorf("Fail to Update the experiment file, due to %v", err)
+
+	}
+	cmd := exec.Command("kubectl", "apply", "-f", testsDetails.ExperimentName+"-exp.yaml", "-n", experimentNamespace)
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err = cmd.Run()
+	if err != nil {
+		klog.Infof(fmt.Sprint(err) + ": " + stderr.String())
+		klog.Infof("Error: %v", err)
+		return errors.Errorf("Fail to create the experiment file, due to {%v}", err)
+	}
+	klog.Infof("[ChaosExperiment]: " + out.String())
+	klog.Info("[ChaosExperiment]: Chaos Experiment created successfully with image: " + testsDetails.AnsibleExperimentImage + " !!!")
+
+	return nil
+}
+
+//InstallAnsibleChaosEngine installs the given ansible based chaos engine
+func InstallAnsibleChaosEngine(testsDetails *types.TestDetails, engineNamespace string) error {
+
+	// Fetch Chaos Engine
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	if err = DownloadFile(testsDetails.ExperimentName+"-ce.yaml", testsDetails.AnsibleEnginePath); err != nil {
+		return errors.Errorf("Fail to fetch the engine file, due to %v", err)
+	}
+	// Modify the spec of engine file
+	if err = EditFile(testsDetails.ExperimentName+"-ce.yaml", "name: nginx-chaos", "name: "+testsDetails.EngineName+""); err != nil {
+		if err = EditFile(testsDetails.ExperimentName+"-ce.yaml", "name: nginx-network-chaos", "name: "+testsDetails.EngineName+""); err != nil {
+			return errors.Errorf("Fail to Update the engine file, due to %v", err)
+		}
+	}
+	if err = EditFile(testsDetails.ExperimentName+"-ce.yaml", "namespace: default", "namespace: "+engineNamespace+""); err != nil {
+		return errors.Errorf("Fail to Update the engine file, due to %v", err)
+	}
+	if err = EditFile(testsDetails.ExperimentName+"-ce.yaml", "appns: 'default'", "appns: "+testsDetails.AppNS+""); err != nil {
+		return errors.Errorf("Fail to Update the engine file, due to %v", err)
+	}
+	if err = EditFile(testsDetails.ExperimentName+"-ce.yaml", "applabel: 'app=nginx'", "applabel: "+testsDetails.AppLabel+""); err != nil {
+		return errors.Errorf("Fail to Update the engine file, due to %v", err)
+	}
+	if err = EditFile(testsDetails.ExperimentName+"-ce.yaml", "jobCleanUpPolicy: 'delete'", "jobCleanUpPolicy: "+testsDetails.JobCleanUpPolicy+""); err != nil {
+		return errors.Errorf("Fail to Update the engine file, due to %v", err)
+	}
+	if err = EditFile(testsDetails.ExperimentName+"-ce.yaml", "annotationCheck: 'true'", "annotationCheck: '"+testsDetails.AnnotationCheck+"'"); err != nil {
+		if err = EditFile(testsDetails.ExperimentName+"-ce.yaml", "annotationCheck: 'false'", "annotationCheck: '"+testsDetails.AnnotationCheck+"'"); err != nil {
+			return errors.Errorf("Fail to Update the engine file, due to %v", err)
+		}
+	}
+
+	if testsDetails.ApplicationNodeName != "" {
+		if err = EditKeyValue(testsDetails.ExperimentName+"-ce.yaml", "APP_NODE", "value: 'node-01'", "value: '"+testsDetails.ApplicationNodeName+"'"); err != nil {
+			return errors.Errorf("Fail to Update the engine file, due to %v", err)
+		}
+		if err = EditFile(testsDetails.ExperimentName+"-ce.yaml", "kubernetes.io/hostname: 'node02'", "kubernetes.io/hostname: '"+testsDetails.NodeSelectorName+"'"); err != nil {
+			return errors.Errorf("Fail to Update the engine file, due to %v", err)
+		}
+	}
+
+	cmd := exec.Command("kubectl", "apply", "-f", testsDetails.ExperimentName+"-ce.yaml", "-n", engineNamespace)
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err = cmd.Run()
+	if err != nil {
+		klog.Infof(fmt.Sprint(err) + ": " + stderr.String())
+		klog.Infof("Error: %v", err)
+		return errors.Errorf("Fail to create the engine file, due to {%v}", err)
+	}
+	klog.Infof("[ChaosEngine]: " + out.String())
+	time.Sleep(2 * time.Second)
+
+	return nil
+}

--- a/pkg/environment/clienset.go
+++ b/pkg/environment/clienset.go
@@ -1,7 +1,6 @@
 package environment
 
 import (
-	"flag"
 	"os"
 
 	chaosClient "github.com/litmuschaos/chaos-operator/pkg/client/clientset/versioned/typed/litmuschaos/v1alpha1"
@@ -44,25 +43,12 @@ func (clientSets *ClientSets) GenerateClientSetFromKubeConfig() error {
 // getKubeConfig setup the config for access cluster resource
 func getKubeConfig() (*rest.Config, error) {
 
-	var kubeconfig *string
-	if _, err := os.Stat(os.Getenv("HOME") + "/.kube/config"); os.IsExist(err) {
-		command := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
-		kubeconfig = command.String("kubeconfig", os.Getenv("HOME")+"/.kube/config", "absolute path to the kubeconfig file")
-		flag.Parse()
-	} else {
-		command := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
-		kubeconfig = command.String("kubeconfig", "", "absolute path to the kubeconfig file")
-		flag.Parse()
+	KubeConfig := os.Getenv("KUBECONFIG")
+	// Use in-cluster config if kubeconfig path is not specified
+	if KubeConfig == "" {
+		return rest.InClusterConfig()
 	}
-
-	// Use in-cluster config if kubeconfig path is specified
-	if *kubeconfig == "" {
-		config, err := rest.InClusterConfig()
-		if err != nil {
-			return config, err
-		}
-	}
-	config, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
+	config, err := clientcmd.BuildConfigFromFlags("", KubeConfig)
 	if err != nil {
 		return config, err
 	}

--- a/pkg/install.go
+++ b/pkg/install.go
@@ -11,144 +11,23 @@ import (
 	"k8s.io/klog"
 )
 
-var (
-	err error
-)
-
-//InstallAnsibleRbac installs and configure rbac for running ansible based chaos
-func InstallAnsibleRbac(testsDetails *types.TestDetails, rbacNamespace string) error {
-
-	//Fetch RBAC file
-	var out bytes.Buffer
-	var stderr bytes.Buffer
-	err = DownloadFile(testsDetails.ExperimentName+"-sa.yaml", testsDetails.AnsibleRbacPath)
-	if err != nil {
-		return errors.Errorf("Fail to fetch the rbac file, due to %v", err)
-	}
-	//Modify Namespace field of the RBAC
-	err = EditFile(testsDetails.ExperimentName+"-sa.yaml", "namespace: default", "namespace: "+rbacNamespace)
-	if err != nil {
-		return errors.Errorf("Fail to Modify rbac file, due to %v", err)
-	}
-	//Creating rbac
-	cmd := exec.Command("kubectl", "apply", "-f", testsDetails.ExperimentName+"-sa.yaml", "-n", rbacNamespace)
-	cmd.Stdout = &out
-	cmd.Stderr = &stderr
-	err = cmd.Run()
-	if err != nil {
-		klog.Infof(fmt.Sprint(err) + ": " + stderr.String())
-		klog.Infof("Error: %v", err)
-		return errors.Errorf("Fail to create the rbac file, due to {%v}", err)
-	}
-	klog.Infof("[RBAC]: " + out.String())
-	klog.Info("[RBAC]: Rbac installed successfully !!!")
-
-	return nil
-}
-
-//InstallAnsibleChaosExperiment installs the given ansible based chaos experiment
-func InstallAnsibleChaosExperiment(testsDetails *types.TestDetails, experimentNamespace string) error {
-
-	// Fetch Chaos Experiment
-	var out bytes.Buffer
-	var stderr bytes.Buffer
-	if err = DownloadFile(testsDetails.ExperimentName+"-exp.yaml", testsDetails.AnsibleExperimentPath); err != nil {
-		return errors.Errorf("Fail to fetch the experiment file, due to %v", err)
-	}
-	// Modify the spec of experiemnt file
-	if err = EditFile(testsDetails.ExperimentName+"-exp.yaml", "image: \"litmuschaos/ansible-runner:latest\"", "image: "+testsDetails.AnsibleExperimentImage); err != nil {
-		return errors.Errorf("Fail to Update the experiment file, due to %v", err)
-
-	}
-	cmd := exec.Command("kubectl", "apply", "-f", testsDetails.ExperimentName+"-exp.yaml", "-n", experimentNamespace)
-	cmd.Stdout = &out
-	cmd.Stderr = &stderr
-	err = cmd.Run()
-	if err != nil {
-		klog.Infof(fmt.Sprint(err) + ": " + stderr.String())
-		klog.Infof("Error: %v", err)
-		return errors.Errorf("Fail to create the experiment file, due to {%v}", err)
-	}
-	klog.Infof("[ChaosExperiment]: " + out.String())
-	klog.Info("[ChaosExperiment]: Chaos Experiment created successfully with image: " + testsDetails.AnsibleExperimentImage + " !!!")
-
-	return nil
-}
-
-//InstallAnsibleChaosEngine installs the given ansible based chaos engine
-func InstallAnsibleChaosEngine(testsDetails *types.TestDetails, engineNamespace string) error {
-
-	// Fetch Chaos Engine
-	var out bytes.Buffer
-	var stderr bytes.Buffer
-	if err = DownloadFile(testsDetails.ExperimentName+"-ce.yaml", testsDetails.AnsibleEnginePath); err != nil {
-		return errors.Errorf("Fail to fetch the engine file, due to %v", err)
-	}
-	// Modify the spec of engine file
-	if err = EditFile(testsDetails.ExperimentName+"-ce.yaml", "name: nginx-chaos", "name: "+testsDetails.EngineName+""); err != nil {
-		if err = EditFile(testsDetails.ExperimentName+"-ce.yaml", "name: nginx-network-chaos", "name: "+testsDetails.EngineName+""); err != nil {
-			return errors.Errorf("Fail to Update the engine file, due to %v", err)
-		}
-	}
-	if err = EditFile(testsDetails.ExperimentName+"-ce.yaml", "namespace: default", "namespace: "+engineNamespace+""); err != nil {
-		return errors.Errorf("Fail to Update the engine file, due to %v", err)
-	}
-	if err = EditFile(testsDetails.ExperimentName+"-ce.yaml", "appns: 'default'", "appns: "+testsDetails.AppNS+""); err != nil {
-		return errors.Errorf("Fail to Update the engine file, due to %v", err)
-	}
-	if err = EditFile(testsDetails.ExperimentName+"-ce.yaml", "applabel: 'app=nginx'", "applabel: "+testsDetails.AppLabel+""); err != nil {
-		return errors.Errorf("Fail to Update the engine file, due to %v", err)
-	}
-	if err = EditFile(testsDetails.ExperimentName+"-ce.yaml", "jobCleanUpPolicy: 'delete'", "jobCleanUpPolicy: "+testsDetails.JobCleanUpPolicy+""); err != nil {
-		return errors.Errorf("Fail to Update the engine file, due to %v", err)
-	}
-	if err = EditFile(testsDetails.ExperimentName+"-ce.yaml", "annotationCheck: 'true'", "annotationCheck: '"+testsDetails.AnnotationCheck+"'"); err != nil {
-		if err = EditFile(testsDetails.ExperimentName+"-ce.yaml", "annotationCheck: 'false'", "annotationCheck: '"+testsDetails.AnnotationCheck+"'"); err != nil {
-			return errors.Errorf("Fail to Update the engine file, due to %v", err)
-		}
-	}
-
-	if testsDetails.ApplicationNodeName != "" {
-		if err = EditKeyValue(testsDetails.ExperimentName+"-ce.yaml", "APP_NODE", "value: 'node-01'", "value: '"+testsDetails.ApplicationNodeName+"'"); err != nil {
-			return errors.Errorf("Fail to Update the engine file, due to %v", err)
-		}
-		if err = EditFile(testsDetails.ExperimentName+"-ce.yaml", "kubernetes.io/hostname: 'node02'", "kubernetes.io/hostname: '"+testsDetails.NodeSelectorName+"'"); err != nil {
-			return errors.Errorf("Fail to Update the engine file, due to %v", err)
-		}
-	}
-
-	cmd := exec.Command("kubectl", "apply", "-f", testsDetails.ExperimentName+"-ce.yaml", "-n", engineNamespace)
-	cmd.Stdout = &out
-	cmd.Stderr = &stderr
-	err = cmd.Run()
-	if err != nil {
-		klog.Infof(fmt.Sprint(err) + ": " + stderr.String())
-		klog.Infof("Error: %v", err)
-		return errors.Errorf("Fail to create the engine file, due to {%v}", err)
-	}
-	klog.Infof("[ChaosEngine]: " + out.String())
-	time.Sleep(2 * time.Second)
-
-	return nil
-}
-
-//InstallGoRbac installs and configure rbac for running ansible based chaos
+//InstallGoRbac installs and configure rbac for running go based chaos
 func InstallGoRbac(testsDetails *types.TestDetails, rbacNamespace string) error {
 
 	//Fetch RBAC file
 	var out bytes.Buffer
 	var stderr bytes.Buffer
-	err = DownloadFile(testsDetails.ExperimentName+"-sa.yaml", testsDetails.RbacPath)
+	err = DownloadFile("/tmp/"+testsDetails.ExperimentName+"-sa.yaml", testsDetails.RbacPath)
 	if err != nil {
 		return errors.Errorf("Fail to fetch the rbac file, due to %v", err)
 	}
 	//Modify Namespace field of the RBAC
-	err = EditFile(testsDetails.ExperimentName+"-sa.yaml", "namespace: default", "namespace: "+rbacNamespace)
+	err = EditFile("/tmp/"+testsDetails.ExperimentName+"-sa.yaml", "namespace: default", "namespace: "+rbacNamespace)
 	if err != nil {
 		return errors.Errorf("Fail to Modify rbac file, due to %v", err)
 	}
 	//Creating rbac
-	cmd := exec.Command("kubectl", "apply", "-f", testsDetails.ExperimentName+"-sa.yaml", "-n", rbacNamespace)
+	cmd := exec.Command("kubectl", "apply", "-f", "/tmp/"+testsDetails.ExperimentName+"-sa.yaml", "-n", rbacNamespace)
 	cmd.Stdout = &out
 	cmd.Stderr = &stderr
 	err = cmd.Run()
@@ -169,20 +48,20 @@ func InstallGoChaosExperiment(testsDetails *types.TestDetails, experimentNamespa
 	// Fetch Chaos Experiment
 	var out bytes.Buffer
 	var stderr bytes.Buffer
-	if err = DownloadFile(testsDetails.ExperimentName+"-exp.yaml", testsDetails.ExperimentPath); err != nil {
+	if err = DownloadFile("/tmp/"+testsDetails.ExperimentName+"-exp.yaml", testsDetails.ExperimentPath); err != nil {
 		return errors.Errorf("Fail to fetch the experiment file, due to %v", err)
 	}
 	// Modify the spec of experiemnt file
-	if err = EditFile(testsDetails.ExperimentName+"-exp.yaml", "image: \"litmuschaos/go-runner:latest\"", "image: "+testsDetails.GoExperimentImage); err != nil {
+	if err = EditFile("/tmp/"+testsDetails.ExperimentName+"-exp.yaml", "image: \"litmuschaos/go-runner:latest\"", "image: "+testsDetails.GoExperimentImage); err != nil {
 		return errors.Errorf("Fail to Update the experiment file, due to %v", err)
 
 	}
 	if testsDetails.TargetPod != "" {
-		if err = EditKeyValue(testsDetails.ExperimentName+"-exp.yaml", "TARGET_PODS", "value: ''", "value: '"+testsDetails.TargetPod+"'"); err != nil {
+		if err = EditKeyValue("/tmp/"+testsDetails.ExperimentName+"-exp.yaml", "TARGET_PODS", "value: ''", "value: '"+testsDetails.TargetPod+"'"); err != nil {
 			return errors.Errorf("Fail to Update the engine file, due to %v", err)
 		}
 	}
-	cmd := exec.Command("kubectl", "apply", "-f", testsDetails.ExperimentName+"-exp.yaml", "-n", experimentNamespace)
+	cmd := exec.Command("kubectl", "apply", "-f", "/tmp/"+testsDetails.ExperimentName+"-exp.yaml", "-n", experimentNamespace)
 	cmd.Stdout = &out
 	cmd.Stderr = &stderr
 	err = cmd.Run()
@@ -197,55 +76,57 @@ func InstallGoChaosExperiment(testsDetails *types.TestDetails, experimentNamespa
 	return nil
 }
 
-//InstallGoChaosEngine installs the given ansible based chaos engine
+//InstallGoChaosEngine installs the given go based chaos engine
 func InstallGoChaosEngine(testsDetails *types.TestDetails, engineNamespace string) error {
 
 	// Fetch Chaos Engine
 	var out bytes.Buffer
 	var stderr bytes.Buffer
-	if err = DownloadFile(testsDetails.ExperimentName+"-ce.yaml", testsDetails.EnginePath); err != nil {
+	if err = DownloadFile("/tmp/"+testsDetails.ExperimentName+"-ce.yaml", testsDetails.EnginePath); err != nil {
 		return errors.Errorf("Fail to fetch the engine file, due to %v", err)
 	}
 	// Modify the spec of engine file
-	if err = EditFile(testsDetails.ExperimentName+"-ce.yaml", "name: nginx-chaos", "name: "+testsDetails.EngineName+""); err != nil {
-		if err = EditFile(testsDetails.ExperimentName+"-ce.yaml", "name: nginx-network-chaos", "name: "+testsDetails.EngineName+""); err != nil {
+	if err = EditFile("/tmp/"+testsDetails.ExperimentName+"-ce.yaml", "name: nginx-chaos", "name: "+testsDetails.EngineName+""); err != nil {
+		if err = EditFile("/tmp/"+testsDetails.ExperimentName+"-ce.yaml", "name: nginx-network-chaos", "name: "+testsDetails.EngineName+""); err != nil {
 			return errors.Errorf("Fail to Update the engine file, due to %v", err)
 		}
 	}
-	if err = EditFile(testsDetails.ExperimentName+"-ce.yaml", "namespace: default", "namespace: "+engineNamespace+""); err != nil {
+	if err = EditFile("/tmp/"+testsDetails.ExperimentName+"-ce.yaml", "namespace: default", "namespace: "+engineNamespace+""); err != nil {
 		return errors.Errorf("Fail to Update the engine file, due to %v", err)
 	}
-	if err = EditFile(testsDetails.ExperimentName+"-ce.yaml", "appns: 'default'", "appns: "+testsDetails.AppNS+""); err != nil {
+	if testsDetails.AppNS != "" && testsDetails.AppLabel != "" {
+		if err = EditFile("/tmp/"+testsDetails.ExperimentName+"-ce.yaml", "appns: 'default'", "appns: "+testsDetails.AppNS+""); err != nil {
+			return errors.Errorf("Fail to Update the engine file, due to %v", err)
+		}
+		if err = EditFile("/tmp/"+testsDetails.ExperimentName+"-ce.yaml", "applabel: 'app=nginx'", "applabel: "+testsDetails.AppLabel+""); err != nil {
+			return errors.Errorf("Fail to Update the engine file, due to %v", err)
+		}
+	}
+	if err = EditFile("/tmp/"+testsDetails.ExperimentName+"-ce.yaml", "chaosServiceAccount: "+testsDetails.ExperimentName+"-sa", "chaosServiceAccount: "+testsDetails.ChaosServiceAccount+""); err != nil {
 		return errors.Errorf("Fail to Update the engine file, due to %v", err)
 	}
-	if err = EditFile(testsDetails.ExperimentName+"-ce.yaml", "applabel: 'app=nginx'", "applabel: "+testsDetails.AppLabel+""); err != nil {
+	if err = EditFile("/tmp/"+testsDetails.ExperimentName+"-ce.yaml", "name: "+testsDetails.ExperimentName+"", "name: "+testsDetails.NewExperimentName+""); err != nil {
 		return errors.Errorf("Fail to Update the engine file, due to %v", err)
 	}
-	if err = EditFile(testsDetails.ExperimentName+"-ce.yaml", "chaosServiceAccount: "+testsDetails.ExperimentName+"-sa", "chaosServiceAccount: "+testsDetails.ChaosServiceAccount+""); err != nil {
+	if err = EditFile("/tmp/"+testsDetails.ExperimentName+"-ce.yaml", "jobCleanUpPolicy: 'delete'", "jobCleanUpPolicy: "+testsDetails.JobCleanUpPolicy+""); err != nil {
 		return errors.Errorf("Fail to Update the engine file, due to %v", err)
 	}
-	if err = EditFile(testsDetails.ExperimentName+"-ce.yaml", "name: "+testsDetails.ExperimentName+"", "name: "+testsDetails.NewExperimentName+""); err != nil {
-		return errors.Errorf("Fail to Update the engine file, due to %v", err)
-	}
-	if err = EditFile(testsDetails.ExperimentName+"-ce.yaml", "jobCleanUpPolicy: 'delete'", "jobCleanUpPolicy: "+testsDetails.JobCleanUpPolicy+""); err != nil {
-		return errors.Errorf("Fail to Update the engine file, due to %v", err)
-	}
-	if err = EditFile(testsDetails.ExperimentName+"-ce.yaml", "annotationCheck: 'true'", "annotationCheck: '"+testsDetails.AnnotationCheck+"'"); err != nil {
-		if err = EditFile(testsDetails.ExperimentName+"-ce.yaml", "annotationCheck: 'false'", "annotationCheck: '"+testsDetails.AnnotationCheck+"'"); err != nil {
+	if err = EditFile("/tmp/"+testsDetails.ExperimentName+"-ce.yaml", "annotationCheck: 'true'", "annotationCheck: '"+testsDetails.AnnotationCheck+"'"); err != nil {
+		if err = EditFile("/tmp/"+testsDetails.ExperimentName+"-ce.yaml", "annotationCheck: 'false'", "annotationCheck: '"+testsDetails.AnnotationCheck+"'"); err != nil {
 			return errors.Errorf("Fail to Update the engine file, due to %v", err)
 		}
 	}
 	if testsDetails.ApplicationNodeName != "" {
-		if err = EditKeyValue(testsDetails.ExperimentName+"-ce.yaml", "TARGET_NODE", "value: 'node-01'", "value: '"+testsDetails.ApplicationNodeName+"'"); err != nil {
-			if err = EditKeyValue(testsDetails.ExperimentName+"-ce.yaml", "TARGET_NODES", "value: 'node-01'", "value: '"+testsDetails.ApplicationNodeName+"'"); err != nil {
+		if err = EditKeyValue("/tmp/"+testsDetails.ExperimentName+"-ce.yaml", "TARGET_NODE", "value: 'node-01'", "value: '"+testsDetails.ApplicationNodeName+"'"); err != nil {
+			if err = EditKeyValue("/tmp/"+testsDetails.ExperimentName+"-ce.yaml", "TARGET_NODES", "value: 'node-01'", "value: '"+testsDetails.ApplicationNodeName+"'"); err != nil {
 				return errors.Errorf("Fail to Update the engine file, due to %v", err)
 			}
 		}
-		if err = EditFile(testsDetails.ExperimentName+"-ce.yaml", "kubernetes.io/hostname: 'node02'", "kubernetes.io/hostname: '"+testsDetails.NodeSelectorName+"'"); err != nil {
+		if err = EditFile("/tmp/"+testsDetails.ExperimentName+"-ce.yaml", "kubernetes.io/hostname: 'node02'", "kubernetes.io/hostname: '"+testsDetails.NodeSelectorName+"'"); err != nil {
 			return errors.Errorf("Fail to Update the engine file, due to %v", err)
 		}
 	}
-	cmd := exec.Command("kubectl", "apply", "-f", testsDetails.ExperimentName+"-ce.yaml", "-n", engineNamespace)
+	cmd := exec.Command("kubectl", "apply", "-f", "/tmp/"+testsDetails.ExperimentName+"-ce.yaml", "-n", engineNamespace)
 	cmd.Stdout = &out
 	cmd.Stderr = &stderr
 	err = cmd.Run()
@@ -302,17 +183,17 @@ func InstallAdminRbac(testsDetails *types.TestDetails) error {
 	//Fetch RBAC file
 	var out bytes.Buffer
 	var stderr bytes.Buffer
-	err = DownloadFile(testsDetails.ExperimentName+"-sa.yaml", testsDetails.AdminRbacPath)
+	err = DownloadFile("/tmp/"+testsDetails.ExperimentName+"-sa.yaml", testsDetails.AdminRbacPath)
 	if err != nil {
 		return errors.Errorf("Fail to fetch the rbac file, due to %v", err)
 	}
 	//Modify Namespace field of the RBAC
-	err = EditFile(testsDetails.ExperimentName+"-sa.yaml", "namespace: litmus", "namespace: "+testsDetails.ChaosNamespace)
+	err = EditFile("/tmp/"+testsDetails.ExperimentName+"-sa.yaml", "namespace: litmus", "namespace: "+testsDetails.ChaosNamespace)
 	if err != nil {
 		return errors.Errorf("Fail to Modify admin rbac file, due to %v", err)
 	}
 	//Creating admin rbac
-	cmd := exec.Command("kubectl", "apply", "-f", testsDetails.ExperimentName+"-sa.yaml", "-n", testsDetails.ChaosNamespace)
+	cmd := exec.Command("kubectl", "apply", "-f", "/tmp/"+testsDetails.ExperimentName+"-sa.yaml", "-n", testsDetails.ChaosNamespace)
 	cmd.Stdout = &out
 	cmd.Stderr = &stderr
 	err = cmd.Run()

--- a/templates/.component-test-template.yml
+++ b/templates/.component-test-template.yml
@@ -165,8 +165,19 @@ App Cleanup In Cluster-1:
   only:
     variables:
     - $COMPONENT_TEST == "true"
+
+Litmus Cleanup In Cluster-1:
+  when: always
+  stage: App Cleanup
+  tags: 
+    - component-test
+  script:
+    - make litmus-cleanup 
+  only:
+    variables:
+    - $COMPONENT_TEST == "true"    
   
-Pipeline Status Check:
+Pipeline Status Update:
   when: always
   stage: App Cleanup
   tags:
@@ -175,4 +186,4 @@ Pipeline Status Check:
     - make pipeline-status-update
   only:
     variables:
-    - $NODE_LEVEL == "true"
+    - $COMPONENT_TEST == "true"

--- a/templates/.node-level-test-template.yml
+++ b/templates/.node-level-test-template.yml
@@ -131,7 +131,18 @@ TCID-VMWx-GENERIC-INFRA-NODE-IO-STRESS:
     - make node-io-stress
   only:
     variables:
-    - $NODE_LEVEL == "true"                 
+    - $NODE_LEVEL == "true"
+
+TCID-VMWx-GENERIC-INFRA-WITHOUT-APP-INFO:
+  when: always
+  stage: Engine Test
+  tags:
+    - node-level-test
+  script:
+    - make without-app-info
+  only:
+    variables:
+    - $NODE_LEVEL == "true"                       
 
 TCID-VMWx-ANSIBLE-INFRA-NODE-CPU-HOG:
   when: always
@@ -175,7 +186,7 @@ TCID-VMWx-ANSIBLE-INFRA-NODE-DRAIN:
     - make ansible-node-drain
   only:
     variables:
-    - $NODE_LEVEL_ANSIBLE_JOB == "true"      
+    - $NODE_LEVEL_ANSIBLE_JOB == "true"
 
 App Cleanup In Cluster-3:
   when: always
@@ -186,7 +197,18 @@ App Cleanup In Cluster-3:
     - make app-cleanup 
   only:
     variables:
-    - $NODE_LEVEL == "true"       
+    - $NODE_LEVEL == "true"
+
+ Litmus Cleanup In Cluster-3:
+  when: always
+  stage: App Cleanup
+  tags: 
+    - node-level-test
+  script:
+    - make litmus-cleanup 
+  only:
+    variables:
+    - $NODE_LEVEL == "true"        
 
 Pipeline Status Check:
   when: always

--- a/templates/.pod-level-test-template.yml
+++ b/templates/.pod-level-test-template.yml
@@ -257,6 +257,17 @@ App Cleanup In Cluster-2:
   only:
     variables:
     - $POD_LEVEL == "true"
+
+Litmus Cleanup In Cluster-2:
+  when: always
+  stage: App Cleanup
+  tags: 
+    - pod-level-test
+  script:
+    - make litmus-cleanup
+  only:
+    variables:
+    - $POD_LEVEL == "true"    
       
 Pipeline Status Check:
   when: always
@@ -267,4 +278,4 @@ Pipeline Status Check:
     - make pipeline-status-update
   only:
     variables:
-    - $NODE_LEVEL == "true"    
+    - $POD_LEVEL == "true"

--- a/tests/app-cleanup_test.go
+++ b/tests/app-cleanup_test.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/klog"
 )
 
-func TestAppCleanUp(t *testing.T) {
+func TestAppCleanUpComponentLevel(t *testing.T) {
 
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "BDD test")

--- a/tests/litmus-cleanup_test.go
+++ b/tests/litmus-cleanup_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"testing"
 
@@ -70,11 +71,13 @@ var _ = Describe("BDD of litmus cleanup", func() {
 			}
 			klog.Info("rbac deleted sucessfully")
 
-			//Delete test deployments from default namespace
-			By("Delete test deployments")
-			err = exec.Command("kubectl", "delete", "deploy", "testapp1", "adminapp", "testapp2").Run()
-			if err != nil {
-				fmt.Println("fail to delete the deployments from default namespace, due to ", err)
+			if os.Getenv("COMPONENT_LEVEL") == "true" {
+				//Delete test deployments from default namespace
+				By("Delete test deployments")
+				err = exec.Command("kubectl", "delete", "deploy", "testapp1", "adminapp", "testapp2").Run()
+				if err != nil {
+					fmt.Println("fail to delete the deployments from default namespace, due to ", err)
+				}
 			}
 
 			//Delete test namespace

--- a/tests/without-appinfo_test.go
+++ b/tests/without-appinfo_test.go
@@ -1,0 +1,811 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/litmuschaos/litmus-e2e/pkg"
+	"github.com/litmuschaos/litmus-e2e/pkg/environment"
+	"github.com/litmuschaos/litmus-e2e/pkg/types"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	"k8s.io/klog"
+)
+
+func TestWithoutAppInfo(t *testing.T) {
+
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "BDD test")
+}
+
+//BDD Tests for node-cpu-hog without appinfo
+var _ = Describe("BDD of node-cpu-hog experiment", func() {
+
+	// BDD for cleaning all components before running the test
+	Context("cleanup for litmus components", func() {
+
+		It("Should delete all the litmus CRs", func() {
+
+			By("[Cleanup]: Removing Litmus Components")
+			err := pkg.Cleanup()
+			Expect(err).To(BeNil(), "Fail to delete all litmus components, due to {%v}", err)
+
+		})
+	})
+
+	// BDD TEST CASE 1
+	Context("Check for litmus components", func() {
+
+		It("Should check for creation of runner pod", func() {
+
+			testsDetails := types.TestDetails{}
+			clients := environment.ClientSets{}
+
+			//Getting kubeConfig and Generate ClientSets
+			By("[PreChaos]: Getting kubeconfig and generate clientset")
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
+
+			//Fetching all the default ENV
+			//Note: please don't provide custom experiment name here
+			By("[PreChaos]: Fetching all default ENVs")
+			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
+			environment.GetENV(&testsDetails, "node-cpu-hog", "node-cpu-engine-without-appinfo")
+
+			// Checking the chaos operator running status
+			By("[Status]: Checking chaos operator status")
+			err = pkg.OperatorStatusCheck(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Operator status check failed, due to {%v}", err)
+
+			//Installing RBAC for the experiment
+			By("[Install]: Installing RBAC")
+			err = pkg.InstallGoRbac(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install rbac, due to {%v}", err)
+
+			//Installing Chaos Experiment for node-cpu-hog
+			By("[Install]: Installing chaos experiment")
+			err = pkg.InstallGoChaosExperiment(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos experiment, due to {%v}", err)
+
+			//Installing Chaos Engine for node-cpu-hog
+			By("[Install]: Installing chaos engine")
+			testsDetails.AppNS = ""
+			testsDetails.AppLabel = ""
+			testsDetails.EnginePath = "https://raw.githubusercontent.com/litmuschaos/litmus-e2e/generic/manifest/without_appinfo/node-cpu-hog.yml"
+			testsDetails.JobCleanUpPolicy = "delete"
+			err = pkg.InstallGoChaosEngine(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaosengine, due to {%v}", err)
+
+			//Checking runner pod running state
+			By("[Status]: Runner pod running status check")
+			testsDetails.AppNS = "litmus"
+			_, err = pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
+
+			//Chaos pod running status check
+			err = pkg.ChaosPodStatus(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Chaos pod status check failed, due to {%v}", err)
+
+			//Waiting for chaos pod to get completed
+			//And Print the logs of the chaos pod
+			By("[Status]: Wait for chaos pod completion and then print logs")
+			err = pkg.ChaosPodLogs(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Fail to get the experiment chaos pod logs, due to {%v}", err)
+
+			//Checking the chaosresult verdict
+			By("[Verdict]: Checking the chaosresult verdict")
+			_, err = pkg.ChaosResultVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
+
+		})
+	})
+	// BDD for checking chaosengine Verdict
+	Context("Check for chaos engine verdict", func() {
+
+		It("Should check for the verdict of experiment", func() {
+
+			testsDetails := types.TestDetails{}
+			clients := environment.ClientSets{}
+
+			//Getting kubeConfig and Generate ClientSets
+			By("[PreChaos]: Getting kubeconfig and generate clientset")
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
+
+			//Fetching all the default ENV
+			By("[PreChaos]: Fetching all default ENVs")
+			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
+			environment.GetENV(&testsDetails, "node-cpu-hog", "node-cpu-engine-without-appinfo")
+
+			//Checking chaosengine verdict
+			By("Checking the Verdict of Chaos Engine")
+			err = pkg.ChaosEngineVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+
+		})
+	})
+
+	// BDD TEST CASE 2
+	Context("Check for litmus components", func() {
+
+		It("Should check for creation of runner pod", func() {
+
+			testsDetails := types.TestDetails{}
+			clients := environment.ClientSets{}
+
+			//Getting kubeConfig and Generate ClientSets
+			By("[PreChaos]: Getting kubeconfig and generate clientset")
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
+
+			//Fetching all the default ENV
+			//Note: please don't provide custom experiment name here
+			By("[PreChaos]: Fetching all default ENVs")
+			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
+			environment.GetENV(&testsDetails, "node-memory-hog", "node-memory-engine-without-appinfo")
+
+			// Checking the chaos operator running status
+			By("[Status]: Checking chaos operator status")
+			err = pkg.OperatorStatusCheck(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Operator status check failed, due to {%v}", err)
+
+			//Installing RBAC for the experiment
+			By("[Install]: Installing RBAC")
+			err = pkg.InstallGoRbac(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install rbac, due to {%v}", err)
+
+			//Installing Chaos Experiment for node-memory-hog
+			By("[Install]: Installing chaos experiment")
+			err = pkg.InstallGoChaosExperiment(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos experiment, due to {%v}", err)
+
+			//Installing Chaos Engine for node-memory-hog
+			By("[Install]: Installing chaos engine")
+			testsDetails.AppNS = ""
+			testsDetails.AppLabel = ""
+			testsDetails.EnginePath = "https://raw.githubusercontent.com/litmuschaos/litmus-e2e/generic/manifest/without_appinfo/node-memory-hog.yml"
+			testsDetails.JobCleanUpPolicy = "delete"
+			err = pkg.InstallGoChaosEngine(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaosengine, due to {%v}", err)
+
+			//Checking runner pod running state
+			By("[Status]: Runner pod running status check")
+			testsDetails.AppNS = "litmus"
+			_, err = pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
+
+			//Chaos pod running status check
+			err = pkg.ChaosPodStatus(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Chaos pod status check failed, due to {%v}", err)
+
+			//Waiting for chaos pod to get completed
+			//And Print the logs of the chaos pod
+			By("[Status]: Wait for chaos pod completion and then print logs")
+			err = pkg.ChaosPodLogs(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Fail to get the experiment chaos pod logs, due to {%v}", err)
+
+			//Checking the chaosresult verdict
+			By("[Verdict]: Checking the chaosresult verdict")
+			_, err = pkg.ChaosResultVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
+
+		})
+	})
+	// BDD for checking chaosengine Verdict
+	Context("Check for chaos engine verdict", func() {
+
+		It("Should check for the verdict of experiment", func() {
+
+			testsDetails := types.TestDetails{}
+			clients := environment.ClientSets{}
+
+			//Getting kubeConfig and Generate ClientSets
+			By("[PreChaos]: Getting kubeconfig and generate clientset")
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
+
+			//Fetching all the default ENV
+			By("[PreChaos]: Fetching all default ENVs")
+			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
+			environment.GetENV(&testsDetails, "node-memory-hog", "node-memory-engine-without-appinfo")
+
+			//Checking chaosengine verdict
+			By("Checking the Verdict of Chaos Engine")
+			err = pkg.ChaosEngineVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+		})
+	})
+	// BDD TEST CASE 3
+	Context("Check for litmus components", func() {
+
+		It("Should check for creation of runner pod", func() {
+
+			testsDetails := types.TestDetails{}
+			clients := environment.ClientSets{}
+
+			//Getting kubeConfig and Generate ClientSets
+			By("[PreChaos]: Getting kubeconfig and generate clientset")
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
+
+			//Fetching all the default ENV
+			By("[PreChaos]: Fetching all default ENVs")
+			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
+			environment.GetENV(&testsDetails, "pod-autoscaler", "pod-autoscaler-engine-wo-appinfo")
+
+			// Checking the chaos operator running status
+			By("[Status]: Checking chaos operator status")
+			err = pkg.OperatorStatusCheck(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Operator status check failed, due to {%v}", err)
+
+			//Installing RBAC for the experiment
+			By("[Install]: Installing RBAC")
+			err = pkg.InstallGoRbac(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install rbac, due to {%v}", err)
+
+			//Installing Chaos Experiment for pod-autoscaler
+			By("[Install]: Installing chaos experiment")
+			err = pkg.InstallGoChaosExperiment(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos experiment, due to {%v}", err)
+
+			//Installing Chaos Engine for pod-autoscaler
+			By("[Install]: Installing chaos engine")
+			testsDetails.AppNS = ""
+			testsDetails.AppLabel = ""
+			testsDetails.EnginePath = "https://raw.githubusercontent.com/litmuschaos/litmus-e2e/generic/manifest/without_appinfo/pod-autoscaler.yml"
+			testsDetails.JobCleanUpPolicy = "delete"
+			err = pkg.InstallGoChaosEngine(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaosengine, due to {%v}", err)
+
+			//Checking runner pod running state
+			By("[Status]: Runner pod running status check")
+			testsDetails.AppNS = "litmus"
+			_, err = pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
+
+			//Chaos pod running status check
+			err = pkg.ChaosPodStatus(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Chaos pod status check failed, due to {%v}", err)
+
+			//Waiting for chaos pod to get completed
+			//And Print the logs of the chaos pod
+			By("[Status]: Wait for chaos pod completion and then print logs")
+			err = pkg.ChaosPodLogs(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Fail to get the experiment chaos pod logs, due to {%v}", err)
+
+			//Checking the chaosresult verdict
+			By("[Verdict]: Checking the chaosresult verdict")
+			_, err = pkg.ChaosResultVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
+
+		})
+	})
+	// BDD for checking chaosengine Verdict
+	Context("Check for chaos engine verdict", func() {
+
+		It("Should check for the verdict of experiment", func() {
+
+			testsDetails := types.TestDetails{}
+			clients := environment.ClientSets{}
+
+			//Getting kubeConfig and Generate ClientSets
+			By("[PreChaos]: Getting kubeconfig and generate clientset")
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
+
+			//Fetching all the default ENV
+			By("[PreChaos]: Fetching all default ENVs")
+			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
+			environment.GetENV(&testsDetails, "pod-autoscaler", "pod-autoscaler-engine-wo-appinfo")
+
+			//Checking chaosengine verdict
+			By("Checking the Verdict of Chaos Engine")
+			err = pkg.ChaosEngineVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+
+		})
+	})
+
+	// BDD for cleaning all components before running the test
+	Context("cleanup for litmus components", func() {
+
+		It("Should delete all the litmus CRs", func() {
+
+			By("[Cleanup]: Removing Litmus Components")
+			err := pkg.Cleanup()
+			Expect(err).To(BeNil(), "Fail to delete all litmus components, due to {%v}", err)
+
+		})
+	})
+	// BDD TEST CASE 4
+	Context("Check for litmus components", func() {
+
+		It("Should check for creation of runner pod", func() {
+
+			testsDetails := types.TestDetails{}
+			clients := environment.ClientSets{}
+
+			//Getting kubeConfig and Generate ClientSets
+			By("[PreChaos]: Getting kubeconfig and generate clientset")
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
+
+			//Fetching all the default ENV
+			//Note: please don't provide custom experiment name here
+			By("[PreChaos]: Fetching all default ENVs")
+			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
+			environment.GetENV(&testsDetails, "kubelet-service-kill", "ksk-engine-without-appinfo")
+
+			// Checking the chaos operator running status
+			By("[Status]: Checking chaos operator status")
+			err = pkg.OperatorStatusCheck(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Operator status check failed, due to {%v}", err)
+
+			// Getting application node name
+			By("[Prepare]: Getting application node name")
+			_, err = pkg.GetApplicationNode(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Unable to get application node name due to {%v}", err)
+
+			// Getting other node for nodeSelector in engine
+			testsDetails.NodeSelectorName, err = pkg.GetSelectorNode(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Error in getting node selector name, due to {%v}", err)
+			Expect(testsDetails.NodeSelectorName).NotTo(BeEmpty(), "Unable to get node name for node selector, due to {%v}", err)
+
+			//Cordon the application node
+			By("Cordoning Application Node")
+			err = pkg.NodeCordon(&testsDetails)
+			Expect(err).To(BeNil(), "Fail to Cordon the app node, due to {%v}", err)
+
+			//Installing RBAC for the experiment
+			By("[Install]: Installing RBAC")
+			err = pkg.InstallGoRbac(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install rbac, due to {%v}", err)
+
+			//Installing Chaos Experiment for kubelet-service-kill
+			By("[Install]: Installing chaos experiment")
+			err = pkg.InstallGoChaosExperiment(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos experiment, due to {%v}", err)
+
+			//Installing Chaos Engine for kubelet-service-kill
+			By("[Install]: Installing chaos engine")
+			testsDetails.AppNS = ""
+			testsDetails.AppLabel = ""
+			testsDetails.EnginePath = "https://raw.githubusercontent.com/litmuschaos/litmus-e2e/generic/manifest/without_appinfo/kubelet-service-kill.yml"
+			testsDetails.JobCleanUpPolicy = "delete"
+			err = pkg.InstallGoChaosEngine(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaosengine, due to {%v}", err)
+
+			//Checking runner pod running state
+			By("[Status]: Runner pod running status check")
+			testsDetails.AppNS = "litmus"
+			_, err = pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
+
+			//Chaos pod running status check
+			err = pkg.ChaosPodStatus(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Chaos pod status check failed, due to {%v}", err)
+
+			//Waiting for chaos pod to get completed
+			//And Print the logs of the chaos pod
+			By("[Status]: Wait for chaos pod completion and then print logs")
+			err = pkg.ChaosPodLogs(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Fail to get the experiment chaos pod logs, due to {%v}", err)
+
+			//Checking the chaosresult verdict
+			By("[Verdict]: Checking the chaosresult verdict")
+			_, err = pkg.ChaosResultVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
+		})
+	})
+
+	//Waiting for experiment job to get completed
+	// BDD for uncordoning the application node
+	Context("Check for application node", func() {
+
+		It("Should uncordon the app node", func() {
+
+			testsDetails := types.TestDetails{}
+			clients := environment.ClientSets{}
+
+			//Getting kubeConfig and Generate ClientSets
+			By("[PreChaos]: Getting kubeconfig and generate clientset")
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig due to {%v}", err)
+
+			// Getting application node name
+			By("[Prepare]: Getting application node name")
+			_, err = pkg.GetApplicationNode(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Unable to get application node name due to {%v}", err)
+
+			//Uncordon the application node
+			By("Uncordoning Application Node")
+			err = pkg.NodeUncordon(&testsDetails)
+			Expect(err).To(BeNil(), "Fail to uncordon the app node, due to {%v}", err)
+
+		})
+	})
+	// BDD for checking chaosengine Verdict
+	Context("Check for chaos engine verdict", func() {
+
+		It("Should check for the verdict of experiment", func() {
+
+			testsDetails := types.TestDetails{}
+			clients := environment.ClientSets{}
+
+			//Getting kubeConfig and Generate ClientSets
+			By("[PreChaos]: Getting kubeconfig and generate clientset")
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig due to {%v}", err)
+
+			//Fetching all the default ENV
+			By("[PreChaos]: Fetching all default ENVs")
+			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
+			environment.GetENV(&testsDetails, "kubelet-service-kill", "ksk-engine-without-appinfo")
+
+			//Checking chaosengine verdict
+			By("Checking the Verdict of Chaos Engine")
+			err = pkg.ChaosEngineVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+
+		})
+	})
+
+	// BDD TEST CASE 5
+	Context("Check for litmus components", func() {
+
+		It("Should check for creation of runner pod", func() {
+
+			testsDetails := types.TestDetails{}
+			clients := environment.ClientSets{}
+
+			//Getting kubeConfig and Generate ClientSets
+			By("[PreChaos]: Getting kubeconfig and generate clientset")
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
+
+			//Fetching all the default ENV
+			//Note: please don't provide custom experiment name here
+			By("[PreChaos]: Fetching all default ENVs")
+			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
+			environment.GetENV(&testsDetails, "node-drain", "node-drain-engine-without-appinfo")
+
+			// Checking the chaos operator running status
+			By("[Status]: Checking chaos operator status")
+			err = pkg.OperatorStatusCheck(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Operator status check failed, due to {%v}", err)
+
+			// Getting application node name
+			By("[Prepare]: Getting application node name")
+			_, err = pkg.GetApplicationNode(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Unable to get application node name due to {%v}", err)
+
+			// Getting other node for nodeSelector in engine
+			testsDetails.NodeSelectorName, err = pkg.GetSelectorNode(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Error in getting node selector name, due to {%v}", err)
+			Expect(testsDetails.NodeSelectorName).NotTo(BeEmpty(), "Unable to get node name for node selector, due to {%v}", err)
+
+			//Cordon the application node
+			By("Cordoning Application Node")
+			err = pkg.NodeCordon(&testsDetails)
+			Expect(err).To(BeNil(), "Fail to Cordon the app node, due to {%v}", err)
+
+			//Installing RBAC for the experiment
+			By("[Install]: Installing RBAC")
+			err = pkg.InstallGoRbac(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install rbac, due to {%v}", err)
+
+			//Installing Chaos Experiment for node-cordon
+			By("[Install]: Installing chaos experiment")
+			err = pkg.InstallGoChaosExperiment(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos experiment, due to {%v}", err)
+
+			//Installing Chaos Engine for node-cordon
+			By("[Install]: Installing chaos engine")
+			testsDetails.AppNS = ""
+			testsDetails.AppLabel = ""
+			testsDetails.EnginePath = "https://raw.githubusercontent.com/litmuschaos/litmus-e2e/generic/manifest/without_appinfo/node-drain.yml"
+			testsDetails.JobCleanUpPolicy = "delete"
+			err = pkg.InstallGoChaosEngine(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos engine, due to {%v}", err)
+
+			//Checking runner pod running state
+			By("[Status]: Runner pod running status check")
+			testsDetails.AppNS = "litmus"
+			_, err = pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
+
+			//Chaos pod running status check
+			err = pkg.ChaosPodStatus(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Chaos pod status check failed, due to {%v}", err)
+
+			//Waiting for chaos pod to get completed
+			//And Print the logs of the chaos pod
+			By("[Status]: Wait for chaos pod completion and then print logs")
+			err = pkg.ChaosPodLogs(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Fail to get the experiment chaos pod logs, due to {%v}", err)
+
+			//Checking the chaosresult verdict
+			By("[Verdict]: Checking the chaosresult verdict")
+			_, err = pkg.ChaosResultVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
+
+		})
+	})
+
+	// BDD for uncordoning the application node
+	Context("Check for application node", func() {
+
+		It("Should uncordon the app node", func() {
+
+			testsDetails := types.TestDetails{}
+			clients := environment.ClientSets{}
+
+			//Getting kubeConfig and Generate ClientSets
+			By("[PreChaos]: Getting kubeconfig and generate clientset")
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig due to {%v}", err)
+
+			// Getting application node name
+			By("[Prepare]: Getting application node name")
+			_, err = pkg.GetApplicationNode(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Unable to get application node name due to {%v}", err)
+
+			//Uncordon the application node
+			By("Uncordoning Application Node")
+			err = pkg.NodeUncordon(&testsDetails)
+			Expect(err).To(BeNil(), "Fail to uncordon the app node, due to {%v}", err)
+
+		})
+	})
+
+	// BDD for checking chaosengine Verdict
+	Context("Check for chaos engine verdict", func() {
+
+		It("Should check for the verdict of experiment", func() {
+
+			testsDetails := types.TestDetails{}
+			clients := environment.ClientSets{}
+
+			//Getting kubeConfig and Generate ClientSets
+			By("[PreChaos]: Getting kubeconfig and generate clientset")
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig due to {%v}", err)
+
+			//Fetching all the default ENV
+			By("[PreChaos]: Fetching all default ENVs")
+			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
+			environment.GetENV(&testsDetails, "node-drain", "node-drain-engine-without-appinfo")
+
+			//Checking chaosengine verdict
+			By("Checking the Verdict of Chaos Engine")
+			err = pkg.ChaosEngineVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+
+		})
+	})
+
+	// BDD TEST CASE 6
+	Context("Check for litmus components", func() {
+
+		It("Should check for creation of runner pod", func() {
+
+			testsDetails := types.TestDetails{}
+			clients := environment.ClientSets{}
+
+			//Getting kubeConfig and Generate ClientSets
+			By("[PreChaos]: Getting kubeconfig and generate clientset")
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
+
+			//Fetching all the default ENV
+			//Note: please don't provide custom experiment name here
+			By("[PreChaos]: Fetching all default ENVs")
+			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
+			environment.GetENV(&testsDetails, "node-taint", "node-taint-engine-without-appinfo")
+
+			// Checking the chaos operator running status
+			By("[Status]: Checking chaos operator status")
+			err = pkg.OperatorStatusCheck(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Operator status check failed, due to {%v}", err)
+
+			// Getting application node name
+			By("[Prepare]: Getting application node name")
+			_, err = pkg.GetApplicationNode(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Unable to get application node name due to {%v}", err)
+
+			// Getting other node for nodeSelector in engine
+			testsDetails.NodeSelectorName, err = pkg.GetSelectorNode(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Error in getting node selector name, due to {%v}", err)
+			Expect(testsDetails.NodeSelectorName).NotTo(BeEmpty(), "Unable to get node name for node selector, due to {%v}", err)
+
+			//Cordon the application node
+			By("Cordoning Application Node")
+			err = pkg.NodeCordon(&testsDetails)
+			Expect(err).To(BeNil(), "Fail to Cordon the app node, due to {%v}", err)
+
+			//Installing RBAC for the experiment
+			By("[Install]: Installing RBAC")
+			err = pkg.InstallGoRbac(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install rbac, due to {%v}", err)
+
+			//Installing Chaos Experiment for node-cordon
+			By("[Install]: Installing chaos experiment")
+			err = pkg.InstallGoChaosExperiment(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos experiment, due to {%v}", err)
+
+			//Installing Chaos Engine for node-cordon
+			By("[Install]: Installing chaos engine")
+			testsDetails.AppNS = ""
+			testsDetails.AppLabel = ""
+			testsDetails.EnginePath = "https://raw.githubusercontent.com/litmuschaos/litmus-e2e/generic/manifest/without_appinfo/node-taint.yml"
+			testsDetails.JobCleanUpPolicy = "delete"
+			err = pkg.InstallGoChaosEngine(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos engine, due to {%v}", err)
+
+			//Checking runner pod running state
+			By("[Status]: Runner pod running status check")
+			testsDetails.AppNS = "litmus"
+			_, err = pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
+
+			//Chaos pod running status check
+			err = pkg.ChaosPodStatus(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Chaos pod status check failed, due to {%v}", err)
+
+			//Waiting for chaos pod to get completed
+			//And Print the logs of the chaos pod
+			By("[Status]: Wait for chaos pod completion and then print logs")
+			err = pkg.ChaosPodLogs(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Fail to get the experiment chaos pod logs, due to {%v}", err)
+
+			//Checking the chaosresult verdict
+			By("[Verdict]: Checking the chaosresult verdict")
+			_, err = pkg.ChaosResultVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
+
+		})
+	})
+	// BDD for uncordoning the application node
+	Context("Check for application node", func() {
+
+		It("Should uncordon the app node", func() {
+
+			testsDetails := types.TestDetails{}
+			clients := environment.ClientSets{}
+
+			//Getting kubeConfig and Generate ClientSets
+			By("[PreChaos]: Getting kubeconfig and generate clientset")
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig due to {%v}", err)
+
+			// Getting application node name
+			By("[Prepare]: Getting application node name")
+			_, err = pkg.GetApplicationNode(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Unable to get application node name due to {%v}", err)
+
+			//Uncordon the application node
+			By("Uncordoning Application Node")
+			err = pkg.NodeUncordon(&testsDetails)
+			Expect(err).To(BeNil(), "Fail to uncordon the app node, due to {%v}", err)
+
+		})
+	})
+
+	// BDD for checking chaosengine Verdict
+	Context("Check for chaos engine verdict", func() {
+
+		It("Should check for the verdict of experiment", func() {
+
+			testsDetails := types.TestDetails{}
+			clients := environment.ClientSets{}
+
+			//Getting kubeConfig and Generate ClientSets
+			By("[PreChaos]: Getting kubeconfig and generate clientset")
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig due to {%v}", err)
+
+			//Fetching all the default ENV
+			By("[PreChaos]: Fetching all default ENVs")
+			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
+			environment.GetENV(&testsDetails, "node-taint", "node-taint-engine-without-appinfo")
+
+			//Checking chaosengine verdict
+			By("Checking the Verdict of Chaos Engine")
+			err = pkg.ChaosEngineVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+
+		})
+	})
+
+	// BDD TEST CASE 7
+	Context("Check for litmus components", func() {
+
+		It("Should check for creation of runner pod", func() {
+
+			testsDetails := types.TestDetails{}
+			clients := environment.ClientSets{}
+
+			//Getting kubeConfig and Generate ClientSets
+			By("[PreChaos]: Getting kubeconfig and generate clientset")
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
+
+			//Fetching all the default ENV
+			//Note: please don't provide custom experiment name here
+			By("[PreChaos]: Fetching all default ENVs")
+			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
+			environment.GetENV(&testsDetails, "node-io-stress", "no-io-stress-engine-wo-appinfo")
+
+			// Checking the chaos operator running status
+			By("[Status]: Checking chaos operator status")
+			err = pkg.OperatorStatusCheck(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Operator status check failed, due to {%v}", err)
+
+			//Installing RBAC for the experiment
+			By("[Install]: Installing RBAC")
+			err = pkg.InstallGoRbac(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install rbac, due to {%v}", err)
+
+			//Installing Chaos Experiment for node-io-stress
+			By("[Install]: Installing chaos experiment")
+			err = pkg.InstallGoChaosExperiment(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaos experiment, due to {%v}", err)
+
+			//Installing Chaos Engine for node-io-stress
+			By("[Install]: Installing chaos engine")
+			testsDetails.AppNS = ""
+			testsDetails.AppLabel = ""
+			testsDetails.EnginePath = "https://raw.githubusercontent.com/litmuschaos/litmus-e2e/generic/manifest/without_appinfo/node-io-stress.yml"
+			testsDetails.JobCleanUpPolicy = "delete"
+			err = pkg.InstallGoChaosEngine(&testsDetails, testsDetails.ChaosNamespace)
+			Expect(err).To(BeNil(), "Fail to install chaosengine, due to {%v}", err)
+
+			//Checking runner pod running state
+			By("[Status]: Runner pod running status check")
+			testsDetails.AppNS = "litmus"
+			_, err = pkg.RunnerPodStatus(&testsDetails, testsDetails.AppNS, clients)
+			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
+
+			//Chaos pod running status check
+			err = pkg.ChaosPodStatus(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Chaos pod status check failed, due to {%v}", err)
+
+			//Waiting for chaos pod to get completed
+			//And Print the logs of the chaos pod
+			By("[Status]: Wait for chaos pod completion and then print logs")
+			err = pkg.ChaosPodLogs(&testsDetails, clients)
+			Expect(err).To(BeNil(), "Fail to get the experiment chaos pod logs, due to {%v}", err)
+
+			//Checking the chaosresult verdict
+			By("[Verdict]: Checking the chaosresult verdict")
+			_, err = pkg.ChaosResultVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
+
+		})
+	})
+	// BDD for checking chaosengine Verdict
+	Context("Check for chaos engine verdict", func() {
+
+		It("Should check for the verdict of experiment", func() {
+
+			testsDetails := types.TestDetails{}
+			clients := environment.ClientSets{}
+
+			//Getting kubeConfig and Generate ClientSets
+			By("[PreChaos]: Getting kubeconfig and generate clientset")
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
+
+			//Fetching all the default ENV
+			By("[PreChaos]: Fetching all default ENVs")
+			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
+			environment.GetENV(&testsDetails, "node-io-stress", "no-io-stress-engine-wo-appinfo")
+
+			//Checking chaosengine verdict
+			By("Checking the Verdict of Chaos Engine")
+			err = pkg.ChaosEngineVerdict(&testsDetails, clients)
+			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+		})
+	})
+
+})


### PR DESCRIPTION
Signed-off-by: Udit Gaurav <udit.gaurav@mayadata.io>

## Details

- This PR includes Without appinfo test for node-level experiments and some refactoring and restructuring stuff.

Issue:
 - https://github.com/litmuschaos/litmus/issues/1532

- [X] Download rbac, exp, engine all in `/tmp` dir before editing and running it.
- [X] Add new test in `template/node-level` also in `.master-plan.yml`.
- [X] Split ansible file into `ansible-install.go` and `install.go`.
- [X] Used variable in place of flag in clientset.
- [X] Removed all `sshpass` and exporting variables from Makefile.
 