### PR TITLE
chore(imagePullPolicy): Add image pull policy to Always in engine for testing latest runner

### DIFF
--- a/pkg/environment/clienset.go
+++ b/pkg/environment/clienset.go
@@ -1,7 +1,6 @@
 package environment
 
 import (
-	"flag"
 	"os"
 
 	chaosClient "github.com/litmuschaos/chaos-operator/pkg/client/clientset/versioned/typed/litmuschaos/v1alpha1"
@@ -44,25 +43,12 @@ func (clientSets *ClientSets) GenerateClientSetFromKubeConfig() error {
 // getKubeConfig setup the config for access cluster resource
 func getKubeConfig() (*rest.Config, error) {
 
-	var kubeconfig *string
-	if _, err := os.Stat(os.Getenv("HOME") + "/.kube/config"); os.IsExist(err) {
-		command := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
-		kubeconfig = command.String("kubeconfig", os.Getenv("HOME")+"/.kube/config", "absolute path to the kubeconfig file")
-		flag.Parse()
-	} else {
-		command := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
-		kubeconfig = command.String("kubeconfig", "", "absolute path to the kubeconfig file")
-		flag.Parse()
+	KubeConfig := os.Getenv("KUBECONFIG")
+	// Use in-cluster config if kubeconfig path is not specified
+	if KubeConfig == "" {
+		return rest.InClusterConfig()
 	}
-
-	// Use in-cluster config if kubeconfig path is specified
-	if *kubeconfig == "" {
-		config, err := rest.InClusterConfig()
-		if err != nil {
-			return config, err
-		}
-	}
-	config, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
+	config, err := clientcmd.BuildConfigFromFlags("", KubeConfig)
 	if err != nil {
 		return config, err
 	}

--- a/pkg/file.go
+++ b/pkg/file.go
@@ -76,11 +76,12 @@ func AddAfterMatch(filepath, key, newvalue string) error {
 
 	for i, line := range lines {
 		if strings.Contains(line, key) {
+			copy(lines[i+2:], lines[i+1:])
 			lines[i+1] = newvalue
 			failFlag = false
 		}
 	}
-	if failFlag == true {
+	if failFlag {
 		return errors.Errorf("Error in adding \"%v\", \"%v\" not found ", newvalue, key)
 	}
 	output := strings.Join(lines, "\n")

--- a/pkg/file.go
+++ b/pkg/file.go
@@ -65,6 +65,33 @@ func EditKeyValue(filepath, key, oldvalue, newvalue string) error {
 	return nil
 }
 
+// AddAfterMatch will add a new line when a match is found
+func AddAfterMatch(filepath, key, newvalue string) error {
+	failFlag := true
+	fileData, err := ioutil.ReadFile(filepath)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to read the given file, due to:%v", err)
+	}
+	lines := strings.Split(string(fileData), "\n")
+
+	for i, line := range lines {
+		if strings.Contains(line, key) {
+			lines[i+1] = newvalue
+			failFlag = false
+		}
+	}
+	if failFlag == true {
+		return errors.Errorf("Error in adding \"%v\", \"%v\" not found ", newvalue, key)
+	}
+	output := strings.Join(lines, "\n")
+	err = ioutil.WriteFile(filepath, []byte(output), 0644)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to write the data in the given file, due to:%v", err)
+	}
+
+	return nil
+}
+
 // DownloadFile will download a url to a local file. It's efficient because it will
 // write as it downloads and not load the whole file into memory.
 func DownloadFile(filepath string, url string) error {

--- a/pkg/install.go
+++ b/pkg/install.go
@@ -206,7 +206,7 @@ func InstallGoChaosEngine(testsDetails *types.TestDetails, engineNamespace strin
 	if err = DownloadFile(testsDetails.ExperimentName+"-ce.yaml", testsDetails.EnginePath); err != nil {
 		return errors.Errorf("Fail to fetch the engine file, due to %v", err)
 	}
-	// Add imagePullPolicy of chaos-runner to ifNotPresent
+	// Add imagePullPolicy of chaos-runner to Always
 	if err = AddAfterMatch(testsDetails.ExperimentName+"-ce.yaml", "jobCleanUpPolicy", "  components:\n    runner:\n      imagePullPolicy: Always"); err != nil {
 		return errors.Errorf("Fail to add a new line due to %v", err)
 	}

--- a/pkg/install.go
+++ b/pkg/install.go
@@ -206,6 +206,10 @@ func InstallGoChaosEngine(testsDetails *types.TestDetails, engineNamespace strin
 	if err = DownloadFile(testsDetails.ExperimentName+"-ce.yaml", testsDetails.EnginePath); err != nil {
 		return errors.Errorf("Fail to fetch the engine file, due to %v", err)
 	}
+	// Add imagePullPolicy of chaos-runner to ifNotPresent
+	if err = AddAfterMatch(testsDetails.ExperimentName+"-ce.yaml", "jobCleanUpPolicy", "  components:\n    runner:\n      imagePullPolicy: Always"); err != nil {
+		return errors.Errorf("Fail to add a new line due to %v", err)
+	}
 	// Modify the spec of engine file
 	if err = EditFile(testsDetails.ExperimentName+"-ce.yaml", "name: nginx-chaos", "name: "+testsDetails.EngineName+""); err != nil {
 		if err = EditFile(testsDetails.ExperimentName+"-ce.yaml", "name: nginx-network-chaos", "name: "+testsDetails.EngineName+""); err != nil {


### PR DESCRIPTION
Signed-off-by: Udit Gaurav <udit.gaurav@mayadata.io>

- Set `imagePullPolicy` of chaos-runner to `Always` for testing in e2e.

The ChaosEngine spec after runner the edit function will look like:

```yaml
apiVersion: litmuschaos.io/v1alpha1
kind: ChaosEngine
metadata:
  name: go-engine9
  namespace: litmus
spec:
  appinfo:
    appns: litmus
    applabel: run=nginx
    appkind: 'deployment'
  # It can be true/false
  annotationCheck: 'false'
  # It can be active/stop
  engineState: 'active'
  #ex. values: ns1:name=percona,ns2:run=nginx
  auxiliaryAppInfo: ''
  chaosServiceAccount: pod-delete-sa
  monitoring: false
  # It can be delete/retain
  jobCleanUpPolicy: 'retain'
  components:
    runner:
      imagePullPolicy: Always
  experiments:
    - name: pod-delete
```
 