### PR TITLE
chore(Fix): Fix the current pipeline failures

### DIFF
--- a/engine/job-cleanup-policy_test.go
+++ b/engine/job-cleanup-policy_test.go
@@ -37,7 +37,7 @@ var _ = Describe("BDD of job cleanup policy test", func() {
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")
 			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
-			environment.GetENV(&testsDetails, "disk-fill", "job-cleanup-policy-engine")
+			environment.GetENV(&testsDetails, "pod-delete", "job-cleanup-policy-engine")
 
 			// Checking the chaos operator running status
 			By("[Status]: Checking chaos operator status")
@@ -49,13 +49,12 @@ var _ = Describe("BDD of job cleanup policy test", func() {
 			err = pkg.InstallGoRbac(&testsDetails, testsDetails.ChaosNamespace)
 			Expect(err).To(BeNil(), "Fail to install rbac, due to {%v}", err)
 
-			//Installing Chaos Experiment for disk-fill
+			//Installing Chaos Experiment for pod-delete
 			By("[Install]: Installing chaos experiment")
-			testsDetails.LibImageCI = "litmuschaos/go-runner:ci"
 			err = pkg.InstallGoChaosExperiment(&testsDetails, testsDetails.ChaosNamespace)
 			Expect(err).To(BeNil(), "Fail to install chaos experiment, due to {%v}", err)
 
-			//Installing Chaos Engine for disk-fill
+			//Installing Chaos Engine for pod-delete
 			By("[Install]: Installing chaos engine")
 			//Providing job-cleanup-policy as 'retain'
 			err = pkg.InstallGoChaosEngine(&testsDetails, testsDetails.ChaosNamespace)
@@ -121,7 +120,7 @@ var _ = Describe("BDD of job cleanup policy test", func() {
 			//Fetching all the default ENV
 			By("[PreChaos]: Fetching all default ENVs")
 			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
-			environment.GetENV(&testsDetails, "disk-fill", "job-cleanup-policy-engine")
+			environment.GetENV(&testsDetails, "pod-delete", "job-cleanup-policy-engine")
 
 			// Checking the chaos operator running status
 			By("[Status]: Checking chaos operator status")
@@ -133,13 +132,12 @@ var _ = Describe("BDD of job cleanup policy test", func() {
 			err = pkg.InstallGoRbac(&testsDetails, testsDetails.ChaosNamespace)
 			Expect(err).To(BeNil(), "Fail to install rbac, due to {%v}", err)
 
-			//Installing Chaos Experiment for disk-fill
+			//Installing Chaos Experiment for pod-delete
 			By("[Install]: Installing chaos experiment")
-			testsDetails.LibImageCI = "litmuschaos/go-runner:ci"
 			err = pkg.InstallGoChaosExperiment(&testsDetails, testsDetails.ChaosNamespace)
 			Expect(err).To(BeNil(), "Fail to install chaos experiment, due to {%v}", err)
 
-			//Installing Chaos Engine for disk-fill
+			//Installing Chaos Engine for pod-delete
 			By("[Install]: Installing chaos engine")
 			//Providing wrong job-cleanup-policy
 			testsDetails.JobCleanUpPolicy = "delete"

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -25,6 +25,9 @@ func GetENV(testDetails *types.TestDetails, expName, engineName string) {
 	testDetails.NewExperimentName = Getenv("NEW_EXPERIMENT_NAME", expName)
 	testDetails.Delay, _ = strconv.Atoi(Getenv("DELAY", "5"))
 	testDetails.Duration, _ = strconv.Atoi(Getenv("DURATION", "90"))
+	testDetails.FillPercentage, _ = strconv.Atoi(Getenv("FILL_PERCENTAGE", "80"))
+	testDetails.ChaosKillCommad = Getenv("CHAOS_KILL_COMMAND", "kill -9 $(ps afx | grep \"[md5sum] /dev/zero\" | awk '{print$1}' | tr '\\n' ' ')")
+	testDetails.UpdateWebsite = Getenv("UPDATE_WEBSITE", "false")
 
 	//All Images for running chaos test
 	testDetails.AnsibleExperimentImage = Getenv("ANSIBLE_EXPERIMENT_IMAGE", "litmuschaos/ansible-runner:ci")

--- a/pkg/file.go
+++ b/pkg/file.go
@@ -76,6 +76,7 @@ func AddAfterMatch(filepath, key, newvalue string) error {
 
 	for i, line := range lines {
 		if strings.Contains(line, key) {
+			lines = append(lines, "")
 			copy(lines[i+2:], lines[i+1:])
 			lines[i+1] = newvalue
 			failFlag = false

--- a/pkg/get.go
+++ b/pkg/get.go
@@ -68,7 +68,7 @@ func GetChaosResultVerdict(testsDetails *types.TestDetails, clients environment.
 			}
 
 			if string(chaosResult.Status.ExperimentStatus.Verdict) == "Awaited" {
-				return errors.Errorf("Vverdict of Chaos Engine is Awaited")
+				return errors.Errorf("Verdict of Chaos Engine is Awaited")
 			}
 			klog.Infof("Chaos Engine Verdict is %v", chaosResult.Status.ExperimentStatus.Verdict)
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -33,4 +33,8 @@ type TestDetails struct {
 	TargetPod              string
 	LibImageDefault        string
 	LibImageCI             string
+	FillPercentage         int
+	ChaosKillCommad        string
+	NetworkLatency         string
+	UpdateWebsite          string
 }

--- a/tests/container-kill_test.go
+++ b/tests/container-kill_test.go
@@ -23,7 +23,7 @@ func TestGoContainerKill(t *testing.T) {
 var _ = Describe("BDD of container-kill experiment", func() {
 
 	// BDD TEST CASE 1
-	Context("Check for litmus components", func() {
+	Context("Check for container-kill experiment", func() {
 
 		It("Should check for creation of runner pod", func() {
 
@@ -83,11 +83,7 @@ var _ = Describe("BDD of container-kill experiment", func() {
 			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 
 		})
-	})
-	// BDD for checking chaosengine Verdict
-	Context("Check for chaos engine verdict", func() {
-
-		It("Should check for the verdict of experiment", func() {
+		It("Should check for the verdict of container kill experiment", func() {
 
 			testsDetails := types.TestDetails{}
 			clients := environment.ClientSets{}
@@ -111,7 +107,7 @@ var _ = Describe("BDD of container-kill experiment", func() {
 
 	// BDD TEST CASE 2
 	//Add abort-chaos for the chaos experiment
-	Context("Abort-Chaos check of litmus component", func() {
+	Context("Abort-Chaos check for container kill chaos", func() {
 
 		It("Should check the abort of container-kill experiment", func() {
 
@@ -189,51 +185,10 @@ var _ = Describe("BDD of container-kill experiment", func() {
 		})
 	})
 
-	// BDD for pipeline result update
-	Context("Check for the result update", func() {
-
-		It("Should check for the result updation", func() {
-
-			testsDetails := types.TestDetails{}
-			clients := environment.ClientSets{}
-
-			//Getting kubeConfig and Generate ClientSets
-			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			err := clients.GenerateClientSetFromKubeConfig()
-			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
-
-			//Fetching all the default ENV
-			By("[PreChaos]: Fetching all default ENVs")
-			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
-			environment.GetENV(&testsDetails, "container-kill", "go-engine1")
-
-			//Getting chaosengine verdict
-			By("Getting Verdict of Chaos Engine")
-			ChaosEngineVerdict, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
-			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
-			Expect(ChaosEngineVerdict).NotTo(BeEmpty(), "Fail to get chaos engine verdict, due to {%v}", err)
-
-			//Getting chaosengine verdict for abort test
-			By("Getting Verdict of Chaos Engine for abort test")
-			testsDetails.EngineName = "container-kill-abort"
-			ChaosEngineVerdictForAbort, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
-			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
-			if ChaosEngineVerdictForAbort != "Stopped" {
-				ChaosEngineVerdict = "Fail"
-				klog.Error("Abort chaos test verdict is not Pass")
-			}
-
-			//Updating the pipeline result table
-			By("Updating the pipeline result table")
-			err = pkg.UpdateResultTable("Kill one container in the application pod", ChaosEngineVerdict, &testsDetails)
-			Expect(err).To(BeNil(), "Job Result Updation failed, due to {%v}", err)
-
-		})
-	})
 	// BDD TEST CASE 3
-	Context("Check for litmus components", func() {
+	Context("Check for container kill experiment", func() {
 
-		It("Should check the experiment when app is annotated", func() {
+		It("Should check the container kill experiment when app is annotated", func() {
 
 			testsDetails := types.TestDetails{}
 			clients := environment.ClientSets{}
@@ -289,14 +244,10 @@ var _ = Describe("BDD of container-kill experiment", func() {
 			By("[Verdict]: Checking the chaosresult verdict")
 			_, err = pkg.ChaosResultVerdict(&testsDetails, clients)
 			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
-
 		})
-	})
 
-	// BDD for checking chaosengine Verdict when the annotation check is set to true
-	Context("Check for chaos engine verdict", func() {
-
-		It("Should check for the verdict of experiment", func() {
+		// Checking chaosengine Verdict when the annotation check is set to true
+		It("Should check for the verdict of abort test in container kill experiment", func() {
 
 			testsDetails := types.TestDetails{}
 			clients := environment.ClientSets{}
@@ -315,6 +266,61 @@ var _ = Describe("BDD of container-kill experiment", func() {
 			By("Checking the Verdict of Chaos Engine")
 			err = pkg.ChaosEngineVerdict(&testsDetails, clients)
 			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+		})
+	})
+	// BDD for pipeline result update
+	Context("Check for the result update", func() {
+
+		It("Should check for the result updation", func() {
+
+			testsDetails := types.TestDetails{}
+			clients := environment.ClientSets{}
+
+			//Getting kubeConfig and Generate ClientSets
+			By("[PreChaos]: Getting kubeconfig and generate clientset")
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
+
+			//Fetching all the default ENV
+			By("[PreChaos]: Fetching all default ENVs")
+			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
+			environment.GetENV(&testsDetails, "container-kill", "go-engine1")
+
+			if testsDetails.UpdateWebsite == "true" {
+				//Getting chaosengine verdict
+				By("Getting Verdict of Chaos Engine")
+				ChaosEngineVerdict, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
+				Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+				Expect(ChaosEngineVerdict).NotTo(BeEmpty(), "Fail to get chaos engine verdict, due to {%v}", err)
+
+				//Getting chaosengine verdict for abort test
+				By("Getting Verdict of Chaos Engine for abort test")
+				testsDetails.EngineName = "container-kill-abort"
+				ChaosEngineVerdictForAbort, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
+				Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+				if ChaosEngineVerdictForAbort != "Stopped" {
+					ChaosEngineVerdict = "Fail"
+					klog.Error("Abort chaos test verdict is not Pass")
+				}
+
+				//Getting chaosengine verdict for annotation test
+				By("Getting Verdict of Chaos Engine for abort test")
+				testsDetails.EngineName = "container-kill-annotated"
+				ChaosEngineVerdictForAnnotation, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
+				Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+				if ChaosEngineVerdictForAnnotation != "Pass" {
+					ChaosEngineVerdict = "Fail"
+					klog.Error("Annotation test verdict is not Pass")
+				}
+
+				//Updating the pipeline result table
+				By("Updating the pipeline result table")
+				err = pkg.UpdateResultTable("Kill one container in the application pod", ChaosEngineVerdict, &testsDetails)
+				Expect(err).To(BeNil(), "Job Result Updation failed, due to {%v}", err)
+			} else {
+				klog.Info("[SKIP]: Skip updating the result on website")
+			}
+
 		})
 	})
 })

--- a/tests/disk-fill_test.go
+++ b/tests/disk-fill_test.go
@@ -22,9 +22,9 @@ func TestGoDiskFill(t *testing.T) {
 var _ = Describe("BDD of disk-fill experiment", func() {
 
 	// BDD TEST CASE 1
-	Context("Check for litmus components", func() {
+	Context("Check for disk fill chaos experiment", func() {
 
-		It("Should check for creation of runner pod", func() {
+		It("Should check for creation of runner pod for disk fill", func() {
 
 			testsDetails := types.TestDetails{}
 			clients := environment.ClientSets{}
@@ -82,11 +82,8 @@ var _ = Describe("BDD of disk-fill experiment", func() {
 			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 
 		})
-	})
-	// BDD for checking chaosengine Verdict
-	Context("Check for chaos engine verdict", func() {
-
-		It("Should check for the verdict of experiment", func() {
+		// BDD for checking chaosengine Verdict
+		It("Should check for the verdict of disk fill experiment", func() {
 
 			testsDetails := types.TestDetails{}
 			clients := environment.ClientSets{}
@@ -108,44 +105,10 @@ var _ = Describe("BDD of disk-fill experiment", func() {
 		})
 	})
 
-	// BDD for pipeline result update
-	Context("Check for the result update", func() {
-
-		It("Should check for the result updation", func() {
-
-			testsDetails := types.TestDetails{}
-			clients := environment.ClientSets{}
-
-			//Getting kubeConfig and Generate ClientSets
-			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			err := clients.GenerateClientSetFromKubeConfig()
-			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
-
-			//Fetching all the default ENV
-			By("[PreChaos]: Fetching all default ENVs")
-			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
-			environment.GetENV(&testsDetails, "disk-fill", "go-engine2")
-
-			//Getting chaosengine verdict
-			By("Getting Verdict of Chaos Engine")
-			//Getting chaosengine verdict
-			By("Getting Verdict of Chaos Engine")
-			ChaosEngineVerdict, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
-			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
-			Expect(ChaosEngineVerdict).NotTo(BeEmpty(), "Fail to get chaos engine verdict, due to {%v}", err)
-
-			//Updating the pipeline result table
-			By("Updating the pipeline result table")
-			err = pkg.UpdateResultTable("Disk Fill Fills up Ephemeral Storage of a Pod", ChaosEngineVerdict, &testsDetails)
-			Expect(err).To(BeNil(), "Job Result Updation failed, due to {%v}", err)
-
-		})
-	})
-
 	// BDD TEST CASE 3
-	Context("Check for litmus components", func() {
+	Context("Check for disk fill experiment", func() {
 
-		It("Should check the experiment when app is annotated", func() {
+		It("Should check the disk fill experiment when app is annotated", func() {
 
 			testsDetails := types.TestDetails{}
 			clients := environment.ClientSets{}
@@ -203,11 +166,7 @@ var _ = Describe("BDD of disk-fill experiment", func() {
 			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 
 		})
-	})
-
-	// BDD for checking chaosengine Verdict when the annotation check is set to true
-	Context("Check for chaos engine verdict", func() {
-
+		// BDD for checking chaosengine Verdict when the annotation check is set to true
 		It("Should check for the verdict of experiment", func() {
 
 			testsDetails := types.TestDetails{}
@@ -229,4 +188,51 @@ var _ = Describe("BDD of disk-fill experiment", func() {
 			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
 		})
 	})
+	// BDD for pipeline result update
+	Context("Check for the result update", func() {
+
+		It("Should check for the result updation", func() {
+
+			testsDetails := types.TestDetails{}
+			clients := environment.ClientSets{}
+
+			//Getting kubeConfig and Generate ClientSets
+			By("[PreChaos]: Getting kubeconfig and generate clientset")
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
+
+			//Fetching all the default ENV
+			By("[PreChaos]: Fetching all default ENVs")
+			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
+			environment.GetENV(&testsDetails, "disk-fill", "go-engine2")
+
+			if testsDetails.UpdateWebsite == "true" {
+				//Getting chaosengine verdict
+				By("Getting Verdict of Chaos Engine")
+				//Getting chaosengine verdict
+				ChaosEngineVerdict, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
+				Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+				Expect(ChaosEngineVerdict).NotTo(BeEmpty(), "Fail to get chaos engine verdict, due to {%v}", err)
+
+				//Getting chaosengine verdict for annotation test
+				By("Getting Verdict of Chaos Engine for abort test")
+				testsDetails.EngineName = "disk-fill-annotated"
+				ChaosEngineVerdictForAnnotation, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
+				Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+				if ChaosEngineVerdictForAnnotation != "Pass" {
+					ChaosEngineVerdict = "Fail"
+					klog.Error("Annotation test verdict is not Pass")
+				}
+
+				//Updating the pipeline result table
+				By("Updating the pipeline result table")
+				err = pkg.UpdateResultTable("Disk Fill Fills up Ephemeral Storage of a Pod", ChaosEngineVerdict, &testsDetails)
+				Expect(err).To(BeNil(), "Job Result Updation failed, due to {%v}", err)
+			} else {
+				klog.Info("[SKIP]: Skip updating the result on website")
+			}
+
+		})
+	})
+
 })

--- a/tests/kubelet-service-kill_test.go
+++ b/tests/kubelet-service-kill_test.go
@@ -22,7 +22,7 @@ func TestGoKubeletServiceKill(t *testing.T) {
 var _ = Describe("BDD of kubelet-service-kill experiment", func() {
 
 	// BDD TEST CASE 1
-	Context("Check for litmus components", func() {
+	Context("Check for kubelet service kill experiment", func() {
 
 		It("Should check for creation of runner pod", func() {
 
@@ -95,12 +95,9 @@ var _ = Describe("BDD of kubelet-service-kill experiment", func() {
 			_, err = pkg.ChaosResultVerdict(&testsDetails, clients)
 			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 		})
-	})
 
-	//Waiting for experiment job to get completed
-	// BDD for uncordoning the application node
-	Context("Check for application node", func() {
-
+		//Waiting for experiment job to get completed
+		// Uncordoning the application node
 		It("Should uncordon the app node", func() {
 
 			testsDetails := types.TestDetails{}
@@ -122,10 +119,8 @@ var _ = Describe("BDD of kubelet-service-kill experiment", func() {
 			Expect(err).To(BeNil(), "Fail to uncordon the app node, due to {%v}", err)
 
 		})
-	})
-	// BDD for checking chaosengine Verdict
-	Context("Check for chaos engine verdict", func() {
 
+		// Checking chaosengine Verdict
 		It("Should check for the verdict of experiment", func() {
 
 			testsDetails := types.TestDetails{}
@@ -166,16 +161,20 @@ var _ = Describe("BDD of kubelet-service-kill experiment", func() {
 			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
 			environment.GetENV(&testsDetails, "kubelet-service-kill", "go-engine3")
 
-			//Getting chaosengine verdict
-			By("Getting Verdict of Chaos Engine")
-			ChaosEngineVerdict, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
-			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
-			Expect(ChaosEngineVerdict).NotTo(BeEmpty(), "Fail to get chaos engine verdict, due to {%v}", err)
+			if testsDetails.UpdateWebsite == "true" {
+				//Getting chaosengine verdict
+				By("Getting Verdict of Chaos Engine")
+				ChaosEngineVerdict, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
+				Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+				Expect(ChaosEngineVerdict).NotTo(BeEmpty(), "Fail to get chaos engine verdict, due to {%v}", err)
 
-			//Updating the pipeline result table
-			By("Updating the pipeline result table")
-			err = pkg.UpdateResultTable("Kills the kubelet service on the application node", ChaosEngineVerdict, &testsDetails)
-			Expect(err).To(BeNil(), "Job Result Updation failed, due to {%v}", err)
+				//Updating the pipeline result table
+				By("Updating the pipeline result table")
+				err = pkg.UpdateResultTable("Kills the kubelet service on the application node", ChaosEngineVerdict, &testsDetails)
+				Expect(err).To(BeNil(), "Job Result Updation failed, due to {%v}", err)
+			} else {
+				klog.Info("[SKIP]: Skip updating the result on website")
+			}
 
 		})
 	})

--- a/tests/litmus-cleanup_test.go
+++ b/tests/litmus-cleanup_test.go
@@ -78,14 +78,14 @@ var _ = Describe("BDD of litmus cleanup", func() {
 				if err != nil {
 					fmt.Println("fail to delete the deployments from default namespace, due to ", err)
 				}
-			}
 
-			//Delete test namespace
-			By("Delete test namespace")
-			err = exec.Command("kubectl", "delete", "ns", "test").Run()
-			Expect(err).To(BeNil(), "Fail to delete test namespace")
-			if err != nil {
-				fmt.Println(err)
+				//Delete test namespace
+				By("Delete test namespace")
+				err = exec.Command("kubectl", "delete", "ns", "test").Run()
+				Expect(err).To(BeNil(), "Fail to delete test namespace")
+				if err != nil {
+					fmt.Println(err)
+				}
 			}
 		})
 

--- a/tests/node-cpu-hog_test.go
+++ b/tests/node-cpu-hog_test.go
@@ -22,7 +22,7 @@ func TestGoNodeCpuHog(t *testing.T) {
 var _ = Describe("BDD of node-cpu-hog experiment", func() {
 
 	// BDD TEST CASE 1
-	Context("Check for litmus components", func() {
+	Context("Check for node cpu hog experiment", func() {
 
 		It("Should check for creation of runner pod", func() {
 
@@ -82,11 +82,8 @@ var _ = Describe("BDD of node-cpu-hog experiment", func() {
 			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 
 		})
-	})
-	// BDD for checking chaosengine Verdict
-	Context("Check for chaos engine verdict", func() {
-
-		It("Should check for the verdict of experiment", func() {
+		// BDD for checking chaosengine Verdict
+		It("Should check for the verdict of node cpu hog experiment", func() {
 
 			testsDetails := types.TestDetails{}
 			clients := environment.ClientSets{}
@@ -127,16 +124,20 @@ var _ = Describe("BDD of node-cpu-hog experiment", func() {
 			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
 			environment.GetENV(&testsDetails, "node-cpu-hog", "go-engine4")
 
-			//Getting chaosengine verdict
-			By("Getting Verdict of Chaos Engine")
-			ChaosEngineVerdict, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
-			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
-			Expect(ChaosEngineVerdict).NotTo(BeEmpty(), "Fail to get chaos engine verdict, due to {%v}", err)
+			if testsDetails.UpdateWebsite == "true" {
+				//Getting chaosengine verdict
+				By("Getting Verdict of Chaos Engine")
+				ChaosEngineVerdict, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
+				Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+				Expect(ChaosEngineVerdict).NotTo(BeEmpty(), "Fail to get chaos engine verdict, due to {%v}", err)
 
-			//Updating the pipeline result table
-			By("Updating the pipeline result table")
-			err = pkg.UpdateResultTable("Exhaust CPU resources on the Kubernetes Node", ChaosEngineVerdict, &testsDetails)
-			Expect(err).To(BeNil(), "Job Result Updation failed, due to {%v}", err)
+				//Updating the pipeline result table
+				By("Updating the pipeline result table")
+				err = pkg.UpdateResultTable("Exhaust CPU resources on the Kubernetes Node", ChaosEngineVerdict, &testsDetails)
+				Expect(err).To(BeNil(), "Job Result Updation failed, due to {%v}", err)
+			} else {
+				klog.Info("[SKIP]: Skip updating the result on website")
+			}
 
 		})
 	})

--- a/tests/node-drain_test.go
+++ b/tests/node-drain_test.go
@@ -22,7 +22,7 @@ func TestGoNodeDrain(t *testing.T) {
 var _ = Describe("BDD of node-drain experiment", func() {
 
 	// BDD TEST CASE 1
-	Context("Check for litmus components", func() {
+	Context("Check for node drain experiment", func() {
 
 		It("Should check for creation of runner pod", func() {
 
@@ -96,11 +96,8 @@ var _ = Describe("BDD of node-drain experiment", func() {
 			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 
 		})
-	})
-	// BDD for uncordoning the application node
-	Context("Check for application node", func() {
-
-		It("Should uncordon the app node", func() {
+		// Uncordoning the application node
+		It("Should uncordon the app node for node drain", func() {
 
 			testsDetails := types.TestDetails{}
 			clients := environment.ClientSets{}
@@ -121,11 +118,8 @@ var _ = Describe("BDD of node-drain experiment", func() {
 			Expect(err).To(BeNil(), "Fail to uncordon the app node, due to {%v}", err)
 
 		})
-	})
-	// BDD for checking chaosengine Verdict
-	Context("Check for chaos engine verdict", func() {
-
-		It("Should check for the verdict of experiment", func() {
+		// Checking chaosengine Verdict
+		It("Should check for the verdict of node drain experiment", func() {
 
 			testsDetails := types.TestDetails{}
 			clients := environment.ClientSets{}
@@ -147,6 +141,7 @@ var _ = Describe("BDD of node-drain experiment", func() {
 
 		})
 	})
+
 	// BDD for pipeline result update
 	Context("Check for the result update", func() {
 
@@ -165,16 +160,20 @@ var _ = Describe("BDD of node-drain experiment", func() {
 			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
 			environment.GetENV(&testsDetails, "node-drain", "go-engine5")
 
-			//Getting chaosengine verdict
-			By("Getting Verdict of Chaos Engine")
-			ChaosEngineVerdict, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
-			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
-			Expect(ChaosEngineVerdict).NotTo(BeEmpty(), "Fail to get chaos engine verdict, due to {%v}", err)
+			if testsDetails.UpdateWebsite == "true" {
+				//Getting chaosengine verdict
+				By("Getting Verdict of Chaos Engine")
+				ChaosEngineVerdict, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
+				Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+				Expect(ChaosEngineVerdict).NotTo(BeEmpty(), "Fail to get chaos engine verdict, due to {%v}", err)
 
-			//Updating the pipeline result table
-			By("Updating the pipeline result table")
-			err = pkg.UpdateResultTable("Drain the node where application pod is scheduled", ChaosEngineVerdict, &testsDetails)
-			Expect(err).To(BeNil(), "Job Result Updation failed, due to {%v}", err)
+				//Updating the pipeline result table
+				By("Updating the pipeline result table")
+				err = pkg.UpdateResultTable("Drain the node where application pod is scheduled", ChaosEngineVerdict, &testsDetails)
+				Expect(err).To(BeNil(), "Job Result Updation failed, due to {%v}", err)
+			} else {
+				klog.Info("[SKIP]: Skip updating the result on website")
+			}
 
 		})
 	})

--- a/tests/node-io-stress_test.go
+++ b/tests/node-io-stress_test.go
@@ -22,7 +22,7 @@ func TestGoNodeIOStress(t *testing.T) {
 var _ = Describe("BDD of node-io-stress experiment", func() {
 
 	// BDD TEST CASE 1
-	Context("Check for litmus components", func() {
+	Context("Check for node io stress experiment", func() {
 
 		It("Should check for creation of runner pod", func() {
 
@@ -82,10 +82,7 @@ var _ = Describe("BDD of node-io-stress experiment", func() {
 			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 
 		})
-	})
-	// BDD for checking chaosengine Verdict
-	Context("Check for chaos engine verdict", func() {
-
+		// BDD for checking chaosengine Verdict
 		It("Should check for the verdict of experiment", func() {
 
 			testsDetails := types.TestDetails{}
@@ -125,16 +122,20 @@ var _ = Describe("BDD of node-io-stress experiment", func() {
 			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
 			environment.GetENV(&testsDetails, "node-io-stress", "go-engine15")
 
-			//Getting chaosengine verdict
-			By("Getting Verdict of Chaos Engine")
-			ChaosEngineVerdict, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
-			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
-			Expect(ChaosEngineVerdict).NotTo(BeEmpty(), "Fail to get chaos engine verdict, due to {%v}", err)
+			if testsDetails.UpdateWebsite == "true" {
+				//Getting chaosengine verdict
+				By("Getting Verdict of Chaos Engine")
+				ChaosEngineVerdict, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
+				Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+				Expect(ChaosEngineVerdict).NotTo(BeEmpty(), "Fail to get chaos engine verdict, due to {%v}", err)
 
-			//Updating the pipeline result table
-			By("Updating the pipeline result table")
-			err = pkg.UpdateResultTable("Give IO disk stress on a node belonging to a deployment", ChaosEngineVerdict, &testsDetails)
-			Expect(err).To(BeNil(), "Job Result Updation failed, due to {%v}", err)
+				//Updating the pipeline result table
+				By("Updating the pipeline result table")
+				err = pkg.UpdateResultTable("Give IO disk stress on a node belonging to a deployment", ChaosEngineVerdict, &testsDetails)
+				Expect(err).To(BeNil(), "Job Result Updation failed, due to {%v}", err)
+			} else {
+				klog.Info("[SKIP]: Skip updating the result on website")
+			}
 
 		})
 	})

--- a/tests/node-memory-hog_test.go
+++ b/tests/node-memory-hog_test.go
@@ -22,7 +22,7 @@ func TestGoNodeMemoryHog(t *testing.T) {
 var _ = Describe("BDD of node-memory-hog experiment", func() {
 
 	// BDD TEST CASE 1
-	Context("Check for litmus components", func() {
+	Context("Check for node memory hog experiment", func() {
 
 		It("Should check for creation of runner pod", func() {
 
@@ -82,10 +82,7 @@ var _ = Describe("BDD of node-memory-hog experiment", func() {
 			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 
 		})
-	})
-	// BDD for checking chaosengine Verdict
-	Context("Check for chaos engine verdict", func() {
-
+		// Checking chaosengine Verdict
 		It("Should check for the verdict of experiment", func() {
 
 			testsDetails := types.TestDetails{}
@@ -125,17 +122,20 @@ var _ = Describe("BDD of node-memory-hog experiment", func() {
 			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
 			environment.GetENV(&testsDetails, "node-memory-hog", "go-engine6")
 
-			//Getting chaosengine verdict
-			By("Getting Verdict of Chaos Engine")
-			ChaosEngineVerdict, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
-			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
-			Expect(ChaosEngineVerdict).NotTo(BeEmpty(), "Fail to get chaos engine verdict, due to {%v}", err)
+			if testsDetails.UpdateWebsite == "true" {
+				//Getting chaosengine verdict
+				By("Getting Verdict of Chaos Engine")
+				ChaosEngineVerdict, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
+				Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+				Expect(ChaosEngineVerdict).NotTo(BeEmpty(), "Fail to get chaos engine verdict, due to {%v}", err)
 
-			//Updating the pipeline result table
-			By("Updating the pipeline result table")
-			err = pkg.UpdateResultTable("Exhaust Memory resources on the Kubernetes Node", ChaosEngineVerdict, &testsDetails)
-			Expect(err).To(BeNil(), "Job Result Updation failed, due to {%v}", err)
-
+				//Updating the pipeline result table
+				By("Updating the pipeline result table")
+				err = pkg.UpdateResultTable("Exhaust Memory resources on the Kubernetes Node", ChaosEngineVerdict, &testsDetails)
+				Expect(err).To(BeNil(), "Job Result Updation failed, due to {%v}", err)
+			} else {
+				klog.Info("[SKIP]: Skip updating the result on website")
+			}
 		})
 	})
 })

--- a/tests/node-taint_test.go
+++ b/tests/node-taint_test.go
@@ -96,10 +96,7 @@ var _ = Describe("BDD of node-taint experiment", func() {
 			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 
 		})
-	})
-	// BDD for uncordoning the application node
-	Context("Check for application node", func() {
-
+		// BDD for uncordoning the application node
 		It("Should uncordon the app node", func() {
 
 			testsDetails := types.TestDetails{}
@@ -121,12 +118,8 @@ var _ = Describe("BDD of node-taint experiment", func() {
 			Expect(err).To(BeNil(), "Fail to uncordon the app node, due to {%v}", err)
 
 		})
-	})
-
-	// BDD for checking chaosengine Verdict
-	Context("Check for chaos engine verdict", func() {
-
-		It("Should check for the verdict of experiment", func() {
+		// BDD for checking chaosengine Verdict
+		It("Should check for the verdict of node taint experiment", func() {
 
 			testsDetails := types.TestDetails{}
 			clients := environment.ClientSets{}
@@ -166,17 +159,20 @@ var _ = Describe("BDD of node-taint experiment", func() {
 			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
 			environment.GetENV(&testsDetails, "node-taint", "go-engine7")
 
-			//Getting chaosengine verdict
-			By("Getting Verdict of Chaos Engine")
-			ChaosEngineVerdict, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
-			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
-			Expect(ChaosEngineVerdict).NotTo(BeEmpty(), "Fail to get chaos engine verdict, due to {%v}", err)
+			if testsDetails.UpdateWebsite == "true" {
+				//Getting chaosengine verdict
+				By("Getting Verdict of Chaos Engine")
+				ChaosEngineVerdict, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
+				Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+				Expect(ChaosEngineVerdict).NotTo(BeEmpty(), "Fail to get chaos engine verdict, due to {%v}", err)
 
-			//Updating the pipeline result table
-			By("Updating the pipeline result table")
-			err = pkg.UpdateResultTable("Drain the node where application pod is scheduled", ChaosEngineVerdict, &testsDetails)
-			Expect(err).To(BeNil(), "Job Result Updation failed, due to {%v}", err)
-
+				//Updating the pipeline result table
+				By("Updating the pipeline result table")
+				err = pkg.UpdateResultTable("Drain the node where application pod is scheduled", ChaosEngineVerdict, &testsDetails)
+				Expect(err).To(BeNil(), "Job Result Updation failed, due to {%v}", err)
+			} else {
+				klog.Info("[SKIP]: Skip updating the result on website")
+			}
 		})
 	})
 })

--- a/tests/pipeline-update_test.go
+++ b/tests/pipeline-update_test.go
@@ -40,25 +40,36 @@ var _ = Describe("BDD of pipeline status update", func() {
 			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
 			environment.GetENV(&testsDetails, "pipeline-update", "")
 
-			//Setup metrics to get pipeline details
-			//Creating rbac
-			cmd := exec.Command("bash", "../metrics/e2e-metrics", "start")
-			cmd.Stdout = &out
-			cmd.Stderr = &stderr
-			err = cmd.Run()
-			klog.Infof(fmt.Sprint(err) + ": " + stderr.String())
-			Expect(err).To(BeNil(), "Fail to setup metrics for pipeline, due to {%v}", err)
+			if testsDetails.UpdateWebsite == "true" {
+				//Setup metrics to get pipeline details
+				//Creating rbac
+				cmd := exec.Command("bash", "../metrics/e2e-metrics", "start")
+				cmd.Stdout = &out
+				cmd.Stderr = &stderr
+				err = cmd.Run()
+				klog.Infof(fmt.Sprint(err) + ": " + stderr.String())
+				Expect(err).To(BeNil(), "Fail to setup metrics for pipeline, due to {%v}", err)
 
-			//Updating the pipeline status table
-			By("Updating the pipeline status table")
-			coverageData, err := ioutil.ReadFile("e2e-metrics/coverage")
-			Expect(err).To(BeNil(), "failed reading coverageData from file, due to {%v}", err)
+				//Updating the pipeline status table
+				By("Updating the pipeline status table")
+				coverageData, err := ioutil.ReadFile("e2e-metrics/coverage")
+				Expect(err).To(BeNil(), "failed reading coverageData from file, due to {%v}", err)
 
-			lines := strings.Split(string(coverageData), "\n")
-			klog.Infof("\nFile Content: %s\n", string(lines[0]))
-			err = pkg.UpdatePipelineStatus(&testsDetails, string(lines[0]))
-			Expect(err).To(BeNil(), "Fail to run the script for pipeline status update,due to {%v}", err)
+				lines := strings.Split(string(coverageData), "\n")
+				klog.Infof("\nFile Content: %s\n", string(lines[0]))
+				err = pkg.UpdatePipelineStatus(&testsDetails, string(lines[0]))
+				Expect(err).To(BeNil(), "Fail to run the script for pipeline status update,due to {%v}", err)
+				klog.Info("Pipeline status updated successfully !!!")
+			} else {
+				klog.Info("[SKIP]: Skip updating the result on website")
+			}
 
+		})
+
+		It("Should check for the result updation", func() {
+
+			var err error
+			var out, stderr bytes.Buffer
 			//Setup metrics to get pipeline details
 			//Creating rbac
 			cmdStop := exec.Command("bash", "../metrics/e2e-metrics", "stop")
@@ -68,8 +79,7 @@ var _ = Describe("BDD of pipeline status update", func() {
 			klog.Infof(fmt.Sprint(err) + ": " + stderr.String())
 			Expect(err).To(BeNil(), "Fail to setup metrics for pipeline, due to {%v}", err)
 
-			klog.Info("Pipeline status updated successfully !!!")
-
 		})
+
 	})
 })

--- a/tests/pod-autoscaler_test.go
+++ b/tests/pod-autoscaler_test.go
@@ -79,10 +79,7 @@ var _ = Describe("BDD of pod-autoscaler experiment", func() {
 			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 
 		})
-	})
-	// BDD for checking chaosengine Verdict
-	Context("Check for chaos engine verdict", func() {
-
+		// BDD for checking chaosengine Verdict
 		It("Should check for the verdict of experiment", func() {
 
 			testsDetails := types.TestDetails{}
@@ -124,16 +121,20 @@ var _ = Describe("BDD of pod-autoscaler experiment", func() {
 			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
 			environment.GetENV(&testsDetails, "pod-autoscaler", "go-engine17")
 
-			//Getting chaosengine verdict
-			By("Getting Verdict of Chaos Engine")
-			ChaosEngineVerdict, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
-			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
-			Expect(ChaosEngineVerdict).NotTo(BeEmpty(), "Fail to get chaos engine verdict, due to {%v}", err)
+			if testsDetails.UpdateWebsite == "true" {
+				//Getting chaosengine verdict
+				By("Getting Verdict of Chaos Engine")
+				ChaosEngineVerdict, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
+				Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+				Expect(ChaosEngineVerdict).NotTo(BeEmpty(), "Fail to get chaos engine verdict, due to {%v}", err)
 
-			//Updating the pipeline result table
-			By("Updating the pipeline result table")
-			err = pkg.UpdateResultTable("Pod Delete test fails the application pod", ChaosEngineVerdict, &testsDetails)
-			Expect(err).To(BeNil(), "Job Result Updation failed, due to {%v}", err)
+				//Updating the pipeline result table
+				By("Updating the pipeline result table")
+				err = pkg.UpdateResultTable("Pod Delete test fails the application pod", ChaosEngineVerdict, &testsDetails)
+				Expect(err).To(BeNil(), "Job Result Updation failed, due to {%v}", err)
+			} else {
+				klog.Info("[SKIP]: Skip updating the result on website")
+			}
 
 		})
 	})

--- a/tests/pod-cpu-hog_test.go
+++ b/tests/pod-cpu-hog_test.go
@@ -82,11 +82,7 @@ var _ = Describe("BDD of pod-cpu-hog experiment", func() {
 			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 
 		})
-	})
-
-	// BDD for checking chaosengine Verdict
-	Context("Check for chaos engine verdict", func() {
-
+		// BDD for checking chaosengine Verdict
 		It("Should check for the verdict of experiment", func() {
 
 			testsDetails := types.TestDetails{}
@@ -187,47 +183,7 @@ var _ = Describe("BDD of pod-cpu-hog experiment", func() {
 			Expect(chaosEngineVerdict).To(Equal("Stopped"), "ChaosEngine Verdict is not Stopped, due to {%v}", err)
 
 		})
-	})
 
-	// BDD for pipeline result update
-	Context("Check for the result update", func() {
-
-		It("Should check for the result updation", func() {
-
-			testsDetails := types.TestDetails{}
-			clients := environment.ClientSets{}
-
-			//Getting kubeConfig and Generate ClientSets
-			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			err := clients.GenerateClientSetFromKubeConfig()
-			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
-
-			//Fetching all the default ENV
-			By("[PreChaos]: Fetching all default ENVs")
-			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
-			environment.GetENV(&testsDetails, "pod-cpu-hog", "go-engine8")
-
-			//Getting chaosengine verdict
-			By("Getting Verdict of Chaos Engine")
-			ChaosEngineVerdict, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
-			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
-			Expect(ChaosEngineVerdict).NotTo(BeEmpty(), "Fail to get chaos engine verdict, due to {%v}", err)
-
-			//Getting chaosengine verdict for abort test
-			By("Getting Verdict of Chaos Engine for abort test")
-			testsDetails.EngineName = "pod-cpu-hog-abort"
-			ChaosEngineVerdictForAbort, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
-			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
-			if ChaosEngineVerdictForAbort != "Stopped" {
-				ChaosEngineVerdict = "Fail"
-				klog.Error("Abort chaos test verdict is not Pass")
-			}
-			//Updating the pipeline result table
-			By("Updating the pipeline result table")
-			err = pkg.UpdateResultTable("Consume CPU resources on the application container", ChaosEngineVerdict, &testsDetails)
-			Expect(err).To(BeNil(), "Job Result Updation failed, due to {%v}", err)
-
-		})
 	})
 
 	// BDD TEST CASE 3
@@ -291,11 +247,8 @@ var _ = Describe("BDD of pod-cpu-hog experiment", func() {
 			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 
 		})
-	})
 
-	// BDD for checking chaosengine Verdict when the annotation check is set to true
-	Context("Check for chaos engine verdict", func() {
-
+		// BDD for checking chaosengine Verdict when the annotation check is set to true
 		It("Should check for the verdict of experiment", func() {
 
 			testsDetails := types.TestDetails{}
@@ -315,6 +268,51 @@ var _ = Describe("BDD of pod-cpu-hog experiment", func() {
 			By("Checking the Verdict of Chaos Engine")
 			err = pkg.ChaosEngineVerdict(&testsDetails, clients)
 			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+		})
+	})
+
+	// BDD for pipeline result update
+	Context("Check for the result update", func() {
+		// BDD for pipeline result update
+		It("Should check for the result updation", func() {
+
+			testsDetails := types.TestDetails{}
+			clients := environment.ClientSets{}
+
+			//Getting kubeConfig and Generate ClientSets
+			By("[PreChaos]: Getting kubeconfig and generate clientset")
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
+
+			//Fetching all the default ENV
+			By("[PreChaos]: Fetching all default ENVs")
+			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
+			environment.GetENV(&testsDetails, "pod-cpu-hog", "go-engine8")
+
+			if testsDetails.UpdateWebsite == "true" {
+				//Getting chaosengine verdict
+				By("Getting Verdict of Chaos Engine")
+				ChaosEngineVerdict, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
+				Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+				Expect(ChaosEngineVerdict).NotTo(BeEmpty(), "Fail to get chaos engine verdict, due to {%v}", err)
+
+				//Getting chaosengine verdict for abort test
+				By("Getting Verdict of Chaos Engine for abort test")
+				testsDetails.EngineName = "pod-cpu-hog-abort"
+				ChaosEngineVerdictForAbort, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
+				Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+				if ChaosEngineVerdictForAbort != "Stopped" {
+					ChaosEngineVerdict = "Fail"
+					klog.Error("Abort chaos test verdict is not Pass")
+				}
+				//Updating the pipeline result table
+				By("Updating the pipeline result table")
+				err = pkg.UpdateResultTable("Consume CPU resources on the application container", ChaosEngineVerdict, &testsDetails)
+				Expect(err).To(BeNil(), "Job Result Updation failed, due to {%v}", err)
+			} else {
+				klog.Info("[SKIP]: Skip updating the result on website")
+			}
+
 		})
 	})
 })

--- a/tests/pod-delete_test.go
+++ b/tests/pod-delete_test.go
@@ -22,9 +22,9 @@ func TestGoPodDelete(t *testing.T) {
 var _ = Describe("BDD of pod-delete experiment", func() {
 
 	// BDD TEST CASE 1
-	Context("Check for litmus components", func() {
+	Context("Check for pod-delete experiment", func() {
 
-		It("Should check for creation of runner pod", func() {
+		It("Should check for the pod delete experiment", func() {
 
 			testsDetails := types.TestDetails{}
 			clients := environment.ClientSets{}
@@ -80,11 +80,7 @@ var _ = Describe("BDD of pod-delete experiment", func() {
 			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 
 		})
-	})
-	// BDD for checking chaosengine Verdict
-	Context("Check for chaos engine verdict", func() {
-
-		It("Should check for the verdict of experiment", func() {
+		It("Should check for the verdict of pod-delete experiment", func() {
 
 			testsDetails := types.TestDetails{}
 			clients := environment.ClientSets{}
@@ -139,7 +135,6 @@ var _ = Describe("BDD of pod-delete experiment", func() {
 
 			//Installing Chaos Experiment
 			By("[Install]: Installing chaos experiment")
-			testsDetails.LibImageCI = "litmuschaos/go-runner:ci"
 			err = pkg.InstallGoChaosExperiment(&testsDetails, testsDetails.ChaosNamespace)
 			Expect(err).To(BeNil(), "Fail to install chaos experiment, due to {%v}", err)
 
@@ -185,53 +180,13 @@ var _ = Describe("BDD of pod-delete experiment", func() {
 			Expect(chaosEngineVerdict).To(Equal("Stopped"), "ChaosEngine Verdict is not Stopped, due to {%v}", err)
 
 		})
-	})
 
-	// BDD for pipeline result update
-	Context("Check for the result update", func() {
-
-		It("Should check for the result updation", func() {
-
-			testsDetails := types.TestDetails{}
-			clients := environment.ClientSets{}
-
-			//Getting kubeConfig and Generate ClientSets
-			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			err := clients.GenerateClientSetFromKubeConfig()
-			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
-
-			//Fetching all the default ENV
-			By("[PreChaos]: Fetching all default ENVs")
-			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
-			environment.GetENV(&testsDetails, "pod-delete", "go-engine9")
-
-			//Getting chaosengine verdict
-			By("Getting Verdict of Chaos Engine")
-			ChaosEngineVerdict, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
-			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
-			Expect(ChaosEngineVerdict).NotTo(BeEmpty(), "Fail to get chaos engine verdict, due to {%v}", err)
-
-			//Getting chaosengine verdict for abort test
-			By("Getting Verdict of Chaos Engine for abort test")
-			testsDetails.EngineName = "pod-delete-abort"
-			ChaosEngineVerdictForAbort, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
-			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
-			if ChaosEngineVerdictForAbort != "Stopped" {
-				ChaosEngineVerdict = "Fail"
-				klog.Error("Abort chaos test verdict is not Pass")
-			}
-			//Updating the pipeline result table
-			By("Updating the pipeline result table")
-			err = pkg.UpdateResultTable("unable to update pipeline result", ChaosEngineVerdict, &testsDetails)
-			Expect(err).To(BeNil(), "Job Result Updation failed, due to {%v}", err)
-
-		})
 	})
 
 	// BDD TEST CASE 3
-	Context("Check for litmus components", func() {
+	Context("Check for pod-delete chaos", func() {
 
-		It("Should check the experiment when app is annotated", func() {
+		It("Should check the pod delete experiment when app is annotated", func() {
 
 			testsDetails := types.TestDetails{}
 			clients := environment.ClientSets{}
@@ -289,12 +244,9 @@ var _ = Describe("BDD of pod-delete experiment", func() {
 			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 
 		})
-	})
 
-	// BDD for checking chaosengine Verdict when the annotation check is set to true
-	Context("Check for chaos engine verdict", func() {
-
-		It("Should check for the verdict of experiment", func() {
+		// BDD for checking chaosengine Verdict when the annotation check is set to true
+		It("Should check for the verdict of pod-delete experiment with annotation set to true", func() {
 
 			testsDetails := types.TestDetails{}
 			clients := environment.ClientSets{}
@@ -313,6 +265,62 @@ var _ = Describe("BDD of pod-delete experiment", func() {
 			By("Checking the Verdict of Chaos Engine")
 			err = pkg.ChaosEngineVerdict(&testsDetails, clients)
 			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+		})
+	})
+
+	// BDD for pipeline result update
+	Context("Check for the result update", func() {
+
+		// BDD for pipeline result update
+		It("Should check for the result updation", func() {
+
+			testsDetails := types.TestDetails{}
+			clients := environment.ClientSets{}
+
+			//Getting kubeConfig and Generate ClientSets
+			By("[PreChaos]: Getting kubeconfig and generate clientset")
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
+
+			//Fetching all the default ENV
+			By("[PreChaos]: Fetching all default ENVs")
+			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
+			environment.GetENV(&testsDetails, "pod-delete", "go-engine9")
+
+			if testsDetails.UpdateWebsite == "true" {
+				//Getting chaosengine verdict
+				By("Getting Verdict of Chaos Engine")
+				ChaosEngineVerdict, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
+				Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+				Expect(ChaosEngineVerdict).NotTo(BeEmpty(), "Fail to get chaos engine verdict, due to {%v}", err)
+
+				//Getting chaosengine verdict for abort test
+				By("Getting Verdict of Chaos Engine for abort test")
+				testsDetails.EngineName = "pod-delete-abort"
+				ChaosEngineVerdictForAbort, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
+				Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+				if ChaosEngineVerdictForAbort != "Stopped" {
+					ChaosEngineVerdict = "Fail"
+					klog.Error("Abort chaos test verdict is not Pass")
+				}
+
+				//Getting chaosengine verdict for annotation test
+				By("Getting Verdict of Chaos Engine for abort test")
+				testsDetails.EngineName = "pod-delete-annotated"
+				ChaosEngineVerdictForAnnotation, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
+				Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+				if ChaosEngineVerdictForAnnotation != "Pass" {
+					ChaosEngineVerdict = "Fail"
+					klog.Error("Annotation check test verdict is not Pass")
+				}
+
+				//Updating the pipeline result table
+				By("Updating the pipeline result table")
+				err = pkg.UpdateResultTable("unable to update pipeline result", ChaosEngineVerdict, &testsDetails)
+				Expect(err).To(BeNil(), "Job Result Updation failed, due to {%v}", err)
+			} else {
+				klog.Info("[SKIP]: Skip updating the result on website")
+			}
 		})
 	})
 })

--- a/tests/pod-io-stress_test.go
+++ b/tests/pod-io-stress_test.go
@@ -23,7 +23,7 @@ func TestGoPodIOStress(t *testing.T) {
 var _ = Describe("BDD of pod-io-stress experiment", func() {
 
 	// BDD TEST CASE 1
-	Context("Check for litmus components", func() {
+	Context("Check for pod-io-stress experiment", func() {
 
 		It("Should check for creation of runner pod", func() {
 
@@ -82,10 +82,7 @@ var _ = Describe("BDD of pod-io-stress experiment", func() {
 			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 
 		})
-	})
-	// BDD for checking chaosengine Verdict
-	Context("Check for chaos engine verdict", func() {
-
+		// BDD for checking chaosengine Verdict
 		It("Should check for the verdict of experiment", func() {
 
 			testsDetails := types.TestDetails{}
@@ -110,7 +107,7 @@ var _ = Describe("BDD of pod-io-stress experiment", func() {
 
 	// BDD TEST CASE 2
 	//Add abort-chaos for the chaos experiment
-	Context("Abort-Chaos check of litmus component", func() {
+	Context("Abort-Chaos check of abort chaos", func() {
 
 		It("Should check the abort of pod-io-stress experiment", func() {
 
@@ -188,46 +185,6 @@ var _ = Describe("BDD of pod-io-stress experiment", func() {
 		})
 	})
 
-	// BDD for pipeline result update
-	Context("Check for the result update", func() {
-
-		It("Should check for the result updation", func() {
-
-			testsDetails := types.TestDetails{}
-			clients := environment.ClientSets{}
-
-			//Getting kubeConfig and Generate ClientSets
-			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			err := clients.GenerateClientSetFromKubeConfig()
-			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
-
-			//Fetching all the default ENV
-			By("[PreChaos]: Fetching all default ENVs")
-			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
-			environment.GetENV(&testsDetails, "pod-io-stress", "go-engine16")
-
-			//Getting chaosengine verdict
-			By("Getting Verdict of Chaos Engine")
-			ChaosEngineVerdict, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
-			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
-			Expect(ChaosEngineVerdict).NotTo(BeEmpty(), "Fail to get chaos engine verdict, due to {%v}", err)
-
-			//Getting chaosengine verdict for abort test
-			By("Getting Verdict of Chaos Engine for abort test")
-			testsDetails.EngineName = "pod-io-stress-abort"
-			ChaosEngineVerdictForAbort, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
-			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
-			if ChaosEngineVerdictForAbort != "Stopped" {
-				ChaosEngineVerdict = "Fail"
-				klog.Error("Abort chaos test verdict is not Pass")
-			}
-			//Updating the pipeline result table
-			By("Updating the pipeline result table")
-			err = pkg.UpdateResultTable("IO stress on a app pods belonging to an app deployment", ChaosEngineVerdict, &testsDetails)
-			Expect(err).To(BeNil(), "Job Result Updation failed, due to {%v}", err)
-
-		})
-	})
 	// BDD TEST CASE 3
 	Context("Check for litmus components", func() {
 
@@ -289,11 +246,8 @@ var _ = Describe("BDD of pod-io-stress experiment", func() {
 			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 
 		})
-	})
 
-	// BDD for checking chaosengine Verdict when the annotation check is set to true
-	Context("Check for chaos engine verdict", func() {
-
+		// BDD for checking chaosengine Verdict when the annotation check is set to true
 		It("Should check for the verdict of experiment", func() {
 
 			testsDetails := types.TestDetails{}
@@ -313,6 +267,61 @@ var _ = Describe("BDD of pod-io-stress experiment", func() {
 			By("Checking the Verdict of Chaos Engine")
 			err = pkg.ChaosEngineVerdict(&testsDetails, clients)
 			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+		})
+	})
+
+	// BDD for pipeline result update
+	Context("Check for the result update", func() {
+
+		It("Should check for the result updation", func() {
+
+			testsDetails := types.TestDetails{}
+			clients := environment.ClientSets{}
+
+			//Getting kubeConfig and Generate ClientSets
+			By("[PreChaos]: Getting kubeconfig and generate clientset")
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
+
+			//Fetching all the default ENV
+			By("[PreChaos]: Fetching all default ENVs")
+			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
+			environment.GetENV(&testsDetails, "pod-io-stress", "go-engine16")
+
+			if testsDetails.UpdateWebsite == "true" {
+				//Getting chaosengine verdict
+				By("Getting Verdict of Chaos Engine")
+				ChaosEngineVerdict, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
+				Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+				Expect(ChaosEngineVerdict).NotTo(BeEmpty(), "Fail to get chaos engine verdict, due to {%v}", err)
+
+				//Getting chaosengine verdict for abort test
+				By("Getting Verdict of Chaos Engine for abort test")
+				testsDetails.EngineName = "pod-io-stress-abort"
+				ChaosEngineVerdictForAbort, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
+				Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+				if ChaosEngineVerdictForAbort != "Stopped" {
+					ChaosEngineVerdict = "Fail"
+					klog.Error("Abort chaos test verdict is not Pass")
+				}
+
+				//Getting chaosengine verdict for annotation test
+				By("Getting Verdict of Chaos Engine for annotation test")
+				testsDetails.EngineName = "pod-io-stress-annotated"
+				ChaosEngineVerdictForAnnotate, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
+				Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+				if ChaosEngineVerdictForAnnotate != "Pass" {
+					ChaosEngineVerdict = "Fail"
+					klog.Error("Annotation test verdict is not Pass")
+				}
+
+				//Updating the pipeline result table
+				By("Updating the pipeline result table")
+				err = pkg.UpdateResultTable("IO stress on a app pods belonging to an app deployment", ChaosEngineVerdict, &testsDetails)
+				Expect(err).To(BeNil(), "Job Result Updation failed, due to {%v}", err)
+			} else {
+				klog.Info("[SKIP]: Skip updating the result on website")
+			}
 		})
 	})
 })

--- a/tests/pod-memory-hog_test.go
+++ b/tests/pod-memory-hog_test.go
@@ -23,7 +23,7 @@ func TestGoMemoryHog(t *testing.T) {
 var _ = Describe("BDD of pod-memory-hog experiment", func() {
 
 	// BDD TEST CASE 1
-	Context("Check for litmus components", func() {
+	Context("Check for pod-memory-hog", func() {
 
 		It("Should check for creation of runner pod", func() {
 
@@ -82,12 +82,9 @@ var _ = Describe("BDD of pod-memory-hog experiment", func() {
 			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 
 		})
-	})
-	// BDD for checking chaosengine Verdict
-	Context("Check for chaos engine verdict", func() {
 
+		// BDD for checking chaosengine Verdict
 		It("Should check for the verdict of experiment", func() {
-
 			testsDetails := types.TestDetails{}
 			clients := environment.ClientSets{}
 
@@ -189,47 +186,6 @@ var _ = Describe("BDD of pod-memory-hog experiment", func() {
 		})
 	})
 
-	// BDD for pipeline result update
-	Context("Check for the result update", func() {
-
-		It("Should check for the result updation", func() {
-
-			testsDetails := types.TestDetails{}
-			clients := environment.ClientSets{}
-
-			//Getting kubeConfig and Generate ClientSets
-			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			err := clients.GenerateClientSetFromKubeConfig()
-			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
-
-			//Fetching all the default ENV
-			By("[PreChaos]: Fetching all default ENVs")
-			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
-			environment.GetENV(&testsDetails, "pod-memory-hog", "go-engine10")
-
-			//Getting chaosengine verdict
-			By("Getting Verdict of Chaos Engine")
-			ChaosEngineVerdict, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
-			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
-			Expect(ChaosEngineVerdict).NotTo(BeEmpty(), "Fail to get chaos engine verdict, due to {%v}", err)
-
-			//Getting chaosengine verdict for abort test
-			By("Getting Verdict of Chaos Engine for abort test")
-			testsDetails.EngineName = "pod-memory-hog-abort"
-			ChaosEngineVerdictForAbort, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
-			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
-			if ChaosEngineVerdictForAbort != "Stopped" {
-				ChaosEngineVerdict = "Fail"
-				klog.Error("Abort chaos test verdict is not Pass")
-			}
-			//Updating the pipeline result table
-			By("Updating the pipeline result table")
-			err = pkg.UpdateResultTable("Consume memory resources on the application container", ChaosEngineVerdict, &testsDetails)
-			Expect(err).To(BeNil(), "Job Result Updation failed, due to {%v}", err)
-
-		})
-	})
-
 	// BDD TEST CASE 3
 	Context("Check for litmus components", func() {
 
@@ -291,11 +247,8 @@ var _ = Describe("BDD of pod-memory-hog experiment", func() {
 			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 
 		})
-	})
 
-	// BDD for checking chaosengine Verdict when the annotation check is set to true
-	Context("Check for chaos engine verdict", func() {
-
+		// BDD for checking chaosengine Verdict when the annotation check is set to true
 		It("Should check for the verdict of experiment", func() {
 
 			testsDetails := types.TestDetails{}
@@ -315,6 +268,62 @@ var _ = Describe("BDD of pod-memory-hog experiment", func() {
 			By("Checking the Verdict of Chaos Engine")
 			err = pkg.ChaosEngineVerdict(&testsDetails, clients)
 			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+		})
+	})
+
+	// BDD for pipeline result update
+	Context("Check for the result update", func() {
+
+		It("Should check for the result updation", func() {
+
+			testsDetails := types.TestDetails{}
+			clients := environment.ClientSets{}
+
+			//Getting kubeConfig and Generate ClientSets
+			By("[PreChaos]: Getting kubeconfig and generate clientset")
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
+
+			//Fetching all the default ENV
+			By("[PreChaos]: Fetching all default ENVs")
+			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
+			environment.GetENV(&testsDetails, "pod-memory-hog", "go-engine10")
+
+			if testsDetails.UpdateWebsite == "true" {
+				//Getting chaosengine verdict
+				By("Getting Verdict of Chaos Engine")
+				ChaosEngineVerdict, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
+				Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+				Expect(ChaosEngineVerdict).NotTo(BeEmpty(), "Fail to get chaos engine verdict, due to {%v}", err)
+
+				//Getting chaosengine verdict for abort test
+				By("Getting Verdict of Chaos Engine for abort test")
+				testsDetails.EngineName = "pod-memory-hog-abort"
+				ChaosEngineVerdictForAbort, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
+				Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+				if ChaosEngineVerdictForAbort != "Stopped" {
+					ChaosEngineVerdict = "Fail"
+					klog.Error("Abort chaos test verdict is not Pass")
+				}
+
+				//Getting chaosengine verdict for annotation test
+				By("Getting Verdict of Chaos Engine for annotation test")
+				testsDetails.EngineName = "pod-memory-hog-annotated"
+				ChaosEngineVerdictForAnnotate, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
+				Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+				if ChaosEngineVerdictForAnnotate != "Pass" {
+					ChaosEngineVerdict = "Fail"
+					klog.Error("Annotation test verdict is not Pass")
+				}
+
+				//Updating the pipeline result table
+				By("Updating the pipeline result table")
+				err = pkg.UpdateResultTable("Consume memory resources on the application container", ChaosEngineVerdict, &testsDetails)
+				Expect(err).To(BeNil(), "Job Result Updation failed, due to {%v}", err)
+			} else {
+				klog.Info("[SKIP]: Skip updating the result on website")
+			}
+
 		})
 	})
 })

--- a/tests/pod-network-corruption_test.go
+++ b/tests/pod-network-corruption_test.go
@@ -23,7 +23,7 @@ func TestGoPodNetworkCorruption(t *testing.T) {
 var _ = Describe("BDD of pod-network-corruption experiment", func() {
 
 	// BDD TEST CASE 1
-	Context("Check for litmus components", func() {
+	Context("Check for pod network corruption", func() {
 
 		It("Should check for creation of runner pod", func() {
 
@@ -93,10 +93,7 @@ var _ = Describe("BDD of pod-network-corruption experiment", func() {
 			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 
 		})
-	})
-	// BDD for checking chaosengine Verdict
-	Context("Check for chaos engine verdict", func() {
-
+		// BDD for checking chaosengine Verdict
 		It("Should check for the verdict of experiment", func() {
 
 			testsDetails := types.TestDetails{}
@@ -200,47 +197,6 @@ var _ = Describe("BDD of pod-network-corruption experiment", func() {
 		})
 	})
 
-	// BDD for pipeline result update
-	Context("Check for the result update", func() {
-
-		It("Should check for the result updation", func() {
-
-			testsDetails := types.TestDetails{}
-			clients := environment.ClientSets{}
-
-			//Getting kubeConfig and Generate ClientSets
-			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			err := clients.GenerateClientSetFromKubeConfig()
-			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
-
-			//Fetching all the default ENV
-			By("[PreChaos]: Fetching all default ENVs")
-			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
-			environment.GetENV(&testsDetails, "pod-network-corruption", "go-engine11")
-
-			//Updating the pipeline result table
-			By("Updating the pipeline result table")
-			//Getting chaosengine verdict
-			By("Getting Verdict of Chaos Engine")
-			ChaosEngineVerdict, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
-			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
-			Expect(ChaosEngineVerdict).NotTo(BeEmpty(), "Fail to get chaos engine verdict, due to {%v}", err)
-
-			//Getting chaosengine verdict for abort test
-			By("Getting Verdict of Chaos Engine for abort test")
-			testsDetails.EngineName = "pod-net-corr-abort"
-			ChaosEngineVerdictForAbort, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
-			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
-			if ChaosEngineVerdictForAbort != "Stopped" {
-				ChaosEngineVerdict = "Fail"
-				klog.Error("Abort chaos test verdict is not Pass")
-			}
-			err = pkg.UpdateResultTable("Inject Network Packet Corruption Into Application Pod", ChaosEngineVerdict, &testsDetails)
-			Expect(err).To(BeNil(), "Job Result Updation failed, due to {%v}", err)
-
-		})
-	})
-
 	// BDD TEST CASE 3
 	Context("Check for litmus components", func() {
 
@@ -302,11 +258,8 @@ var _ = Describe("BDD of pod-network-corruption experiment", func() {
 			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 
 		})
-	})
 
-	// BDD for checking chaosengine Verdict when the annotation check is set to true
-	Context("Check for chaos engine verdict", func() {
-
+		// BDD for checking chaosengine Verdict when the annotation check is set to true
 		It("Should check for the verdict of experiment", func() {
 
 			testsDetails := types.TestDetails{}
@@ -326,6 +279,61 @@ var _ = Describe("BDD of pod-network-corruption experiment", func() {
 			By("Checking the Verdict of Chaos Engine")
 			err = pkg.ChaosEngineVerdict(&testsDetails, clients)
 			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+		})
+	})
+
+	// BDD for pipeline result update
+	Context("Check for the result update", func() {
+
+		It("Should check for the result updation", func() {
+
+			testsDetails := types.TestDetails{}
+			clients := environment.ClientSets{}
+
+			//Getting kubeConfig and Generate ClientSets
+			By("[PreChaos]: Getting kubeconfig and generate clientset")
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
+
+			//Fetching all the default ENV
+			By("[PreChaos]: Fetching all default ENVs")
+			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
+			environment.GetENV(&testsDetails, "pod-network-corruption", "go-engine11")
+
+			if testsDetails.UpdateWebsite == "true" {
+				//Updating the pipeline result table
+				By("Updating the pipeline result table")
+				//Getting chaosengine verdict
+				By("Getting Verdict of Chaos Engine")
+				ChaosEngineVerdict, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
+				Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+				Expect(ChaosEngineVerdict).NotTo(BeEmpty(), "Fail to get chaos engine verdict, due to {%v}", err)
+
+				//Getting chaosengine verdict for abort test
+				By("Getting Verdict of Chaos Engine for abort test")
+				testsDetails.EngineName = "pod-net-corr-abort"
+				ChaosEngineVerdictForAbort, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
+				Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+				if ChaosEngineVerdictForAbort != "Stopped" {
+					ChaosEngineVerdict = "Fail"
+					klog.Error("Abort chaos test verdict is not Pass")
+				}
+
+				//Getting chaosengine verdict for annotation test
+				By("Getting Verdict of Chaos Engine for annotation test")
+				testsDetails.EngineName = "pod-network-corruption-annotated"
+				ChaosEngineVerdictForAnnotate, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
+				Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+				if ChaosEngineVerdictForAnnotate != "Pass" {
+					ChaosEngineVerdict = "Fail"
+					klog.Error("Annotation test verdict is not Pass")
+				}
+
+				err = pkg.UpdateResultTable("Inject Network Packet Corruption Into Application Pod", ChaosEngineVerdict, &testsDetails)
+				Expect(err).To(BeNil(), "Job Result Updation failed, due to {%v}", err)
+			} else {
+				klog.Info("[SKIP]: Skip updating the result on website")
+			}
 		})
 	})
 })

--- a/tests/pod-network-duplication_test.go
+++ b/tests/pod-network-duplication_test.go
@@ -23,7 +23,7 @@ func TestGoPodNetworkDuplication(t *testing.T) {
 var _ = Describe("BDD of pod-network-duplication experiment", func() {
 
 	// BDD TEST CASE 1
-	Context("Check for litmus components", func() {
+	Context("Check for pod network duplication", func() {
 
 		It("Should check for creation of runner pod", func() {
 
@@ -83,10 +83,7 @@ var _ = Describe("BDD of pod-network-duplication experiment", func() {
 			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 
 		})
-	})
-	// BDD for checking chaosengine Verdict
-	Context("Check for chaos engine verdict", func() {
-
+		// BDD for checking chaosengine Verdict
 		It("Should check for the verdict of experiment", func() {
 
 			testsDetails := types.TestDetails{}
@@ -190,46 +187,6 @@ var _ = Describe("BDD of pod-network-duplication experiment", func() {
 		})
 	})
 
-	// BDD for pipeline result update
-	Context("Check for the result update", func() {
-
-		It("Should check for the result updation", func() {
-
-			testsDetails := types.TestDetails{}
-			clients := environment.ClientSets{}
-
-			//Getting kubeConfig and Generate ClientSets
-			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			err := clients.GenerateClientSetFromKubeConfig()
-			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
-
-			//Fetching all the default ENV
-			By("[PreChaos]: Fetching all default ENVs")
-			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
-			environment.GetENV(&testsDetails, "pod-network-duplication", "go-engine12")
-
-			//Updating the pipeline result table
-			By("Updating the pipeline result table")
-			//Getting chaosengine verdict
-			By("Getting Verdict of Chaos Engine")
-			ChaosEngineVerdict, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
-			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
-			Expect(ChaosEngineVerdict).NotTo(BeEmpty(), "Fail to get chaos engine verdict, due to {%v}", err)
-
-			//Getting chaosengine verdict for abort test
-			By("Getting Verdict of Chaos Engine for abort test")
-			testsDetails.EngineName = "pod-net-dup-abort"
-			ChaosEngineVerdictForAbort, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
-			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
-			if ChaosEngineVerdictForAbort != "Stopped" {
-				ChaosEngineVerdict = "Fail"
-				klog.Error("Abort chaos test verdict is not Pass")
-			}
-			err = pkg.UpdateResultTable("Injects chaos to disrupt network connectivity of pod", ChaosEngineVerdict, &testsDetails)
-			Expect(err).To(BeNil(), "Job Result Updation failed, due to {%v}", err)
-
-		})
-	})
 	// BDD TEST CASE 3
 	Context("Check for litmus components", func() {
 
@@ -291,11 +248,8 @@ var _ = Describe("BDD of pod-network-duplication experiment", func() {
 			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 
 		})
-	})
 
-	// BDD for checking chaosengine Verdict when the annotation check is set to true
-	Context("Check for chaos engine verdict", func() {
-
+		// BDD for checking chaosengine Verdict when the annotation check is set to true
 		It("Should check for the verdict of experiment", func() {
 
 			testsDetails := types.TestDetails{}
@@ -315,6 +269,61 @@ var _ = Describe("BDD of pod-network-duplication experiment", func() {
 			By("Checking the Verdict of Chaos Engine")
 			err = pkg.ChaosEngineVerdict(&testsDetails, clients)
 			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+		})
+	})
+
+	// BDD for pipeline result update
+	Context("Check for the result update", func() {
+
+		It("Should check for the result updation", func() {
+
+			testsDetails := types.TestDetails{}
+			clients := environment.ClientSets{}
+
+			//Getting kubeConfig and Generate ClientSets
+			By("[PreChaos]: Getting kubeconfig and generate clientset")
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
+
+			//Fetching all the default ENV
+			By("[PreChaos]: Fetching all default ENVs")
+			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
+			environment.GetENV(&testsDetails, "pod-network-duplication", "go-engine12")
+
+			if testsDetails.UpdateWebsite == "true" {
+				//Updating the pipeline result table
+				By("Updating the pipeline result table")
+				//Getting chaosengine verdict
+				By("Getting Verdict of Chaos Engine")
+				ChaosEngineVerdict, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
+				Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+				Expect(ChaosEngineVerdict).NotTo(BeEmpty(), "Fail to get chaos engine verdict, due to {%v}", err)
+
+				//Getting chaosengine verdict for abort test
+				By("Getting Verdict of Chaos Engine for abort test")
+				testsDetails.EngineName = "pod-net-dup-abort"
+				ChaosEngineVerdictForAbort, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
+				Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+				if ChaosEngineVerdictForAbort != "Stopped" {
+					ChaosEngineVerdict = "Fail"
+					klog.Error("Abort chaos test verdict is not Pass")
+				}
+
+				//Getting chaosengine verdict for annotation test
+				By("Getting Verdict of Chaos Engine for annotation test")
+				testsDetails.EngineName = "pnd-annotated"
+				ChaosEngineVerdictForAnnotate, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
+				Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+				if ChaosEngineVerdictForAnnotate != "Pass" {
+					ChaosEngineVerdict = "Fail"
+					klog.Error("Annotation test verdict is not Pass")
+				}
+
+				err = pkg.UpdateResultTable("Injects chaos to disrupt network connectivity of pod", ChaosEngineVerdict, &testsDetails)
+				Expect(err).To(BeNil(), "Job Result Updation failed, due to {%v}", err)
+			} else {
+				klog.Info("[SKIP]: Skip updating the result on website")
+			}
 		})
 	})
 })

--- a/tests/pod-network-latency_test.go
+++ b/tests/pod-network-latency_test.go
@@ -23,7 +23,7 @@ func TestGoPodNetworkLatency(t *testing.T) {
 var _ = Describe("BDD of pod-network-latency experiment", func() {
 
 	// BDD TEST CASE 1
-	Context("Check for litmus components", func() {
+	Context("Check for pod network latency", func() {
 
 		It("Should check for creation of runner pod", func() {
 
@@ -65,6 +65,7 @@ var _ = Describe("BDD of pod-network-latency experiment", func() {
 
 			//Installing Chaos Engine for pod-network-latency
 			By("[Install]: Installing chaos engine")
+			testsDetails.NetworkLatency = "60000"
 			err = pkg.InstallGoChaosEngine(&testsDetails, testsDetails.ChaosNamespace)
 			Expect(err).To(BeNil(), "Fail to install chaosengine, due to {%v}", err)
 
@@ -93,10 +94,8 @@ var _ = Describe("BDD of pod-network-latency experiment", func() {
 			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 
 		})
-	})
-	// BDD for checking chaosengine Verdict
-	Context("Check for chaos engine verdict", func() {
 
+		// Checking chaosengine Verdict
 		It("Should check for the verdict of experiment", func() {
 
 			testsDetails := types.TestDetails{}
@@ -158,6 +157,7 @@ var _ = Describe("BDD of pod-network-latency experiment", func() {
 
 			//Installing Chaos Engine for pod-network-latency
 			By("[Install]: Installing chaos engine")
+			testsDetails.NetworkLatency = "60000"
 			err = pkg.InstallGoChaosEngine(&testsDetails, testsDetails.ChaosNamespace)
 			Expect(err).To(BeNil(), "Fail to install chaosengine, due to {%v}", err)
 
@@ -200,48 +200,6 @@ var _ = Describe("BDD of pod-network-latency experiment", func() {
 		})
 	})
 
-	// BDD for pipeline result update
-	Context("Check for the result update", func() {
-
-		It("Should check for the result updation", func() {
-
-			testsDetails := types.TestDetails{}
-			clients := environment.ClientSets{}
-
-			//Getting kubeConfig and Generate ClientSets
-			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			err := clients.GenerateClientSetFromKubeConfig()
-			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
-
-			//Fetching all the default ENV
-			By("[PreChaos]: Fetching all default ENVs")
-			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
-			environment.GetENV(&testsDetails, "pod-network-latency", "go-engine13")
-
-			//Updating the pipeline result table
-			By("Updating the pipeline result table")
-			//Getting chaosengine verdict for experiment test
-			By("Getting Verdict of Chaos Engine for experiment test")
-			ChaosEngineVerdict, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
-			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
-			Expect(ChaosEngineVerdict).NotTo(BeEmpty(), "Fail to get chaos engine verdict, due to {%v}", err)
-
-			//Getting chaosengine verdict for abort test
-			By("Getting Verdict of Chaos Engine for abort test")
-			testsDetails.EngineName = "pod-net-lat-abort"
-			ChaosEngineVerdictForAbort, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
-			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
-			if ChaosEngineVerdictForAbort != "Stopped" {
-				ChaosEngineVerdict = "Fail"
-				klog.Error("Abort chaos test verdict is not Pass")
-			}
-
-			err = pkg.UpdateResultTable("Inject Network Latency Into Application Pod", ChaosEngineVerdict, &testsDetails)
-			Expect(err).To(BeNil(), "Job Result Updation failed, due to {%v}", err)
-
-		})
-	})
-
 	// BDD TEST CASE 3
 	Context("Check for litmus components", func() {
 
@@ -279,6 +237,7 @@ var _ = Describe("BDD of pod-network-latency experiment", func() {
 			//Installing Chaos Engine for pod-network-latency
 			By("[Install]: Installing chaos engine")
 			testsDetails.AnnotationCheck = "true"
+			testsDetails.NetworkLatency = "60000"
 			err = pkg.InstallGoChaosEngine(&testsDetails, testsDetails.ChaosNamespace)
 			Expect(err).To(BeNil(), "Fail to install chaosengine, due to {%v}", err)
 
@@ -303,11 +262,7 @@ var _ = Describe("BDD of pod-network-latency experiment", func() {
 			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 
 		})
-	})
-
-	// BDD for checking chaosengine Verdict when the annotation check is set to true
-	Context("Check for chaos engine verdict", func() {
-
+		// BDD for checking chaosengine Verdict when the annotation check is set to true
 		It("Should check for the verdict of experiment", func() {
 
 			testsDetails := types.TestDetails{}
@@ -327,6 +282,61 @@ var _ = Describe("BDD of pod-network-latency experiment", func() {
 			By("Checking the Verdict of Chaos Engine")
 			err = pkg.ChaosEngineVerdict(&testsDetails, clients)
 			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+		})
+	})
+
+	// BDD for pipeline result update
+	Context("Check for the result update", func() {
+
+		It("Should check for the result updation", func() {
+
+			testsDetails := types.TestDetails{}
+			clients := environment.ClientSets{}
+
+			//Getting kubeConfig and Generate ClientSets
+			By("[PreChaos]: Getting kubeconfig and generate clientset")
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
+
+			//Fetching all the default ENV
+			By("[PreChaos]: Fetching all default ENVs")
+			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
+			environment.GetENV(&testsDetails, "pod-network-latency", "go-engine13")
+
+			if testsDetails.UpdateWebsite == "true" {
+				//Updating the pipeline result table
+				By("Updating the pipeline result table")
+				//Getting chaosengine verdict for experiment test
+				By("Getting Verdict of Chaos Engine for experiment test")
+				ChaosEngineVerdict, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
+				Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+				Expect(ChaosEngineVerdict).NotTo(BeEmpty(), "Fail to get chaos engine verdict, due to {%v}", err)
+
+				//Getting chaosengine verdict for abort test
+				By("Getting Verdict of Chaos Engine for abort test")
+				testsDetails.EngineName = "pod-net-lat-abort"
+				ChaosEngineVerdictForAbort, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
+				Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+				if ChaosEngineVerdictForAbort != "Stopped" {
+					ChaosEngineVerdict = "Fail"
+					klog.Error("Abort chaos test verdict is not Pass")
+				}
+
+				//Getting chaosengine verdict for annotation test
+				By("Getting Verdict of Chaos Engine for annotation test")
+				testsDetails.EngineName = "pnlat-annotated"
+				ChaosEngineVerdictForAnnotate, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
+				Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+				if ChaosEngineVerdictForAnnotate != "Pass" {
+					ChaosEngineVerdict = "Fail"
+					klog.Error("Annotation test verdict is not Pass")
+				}
+
+				err = pkg.UpdateResultTable("Inject Network Latency Into Application Pod", ChaosEngineVerdict, &testsDetails)
+				Expect(err).To(BeNil(), "Job Result Updation failed, due to {%v}", err)
+			} else {
+				klog.Info("[SKIP]: Skip updating the result on website")
+			}
 		})
 	})
 })

--- a/tests/pod-network-loss_test.go
+++ b/tests/pod-network-loss_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"log"
 	"testing"
 	"time"
 
@@ -24,7 +23,7 @@ func TestGoPodNetwokLoss(t *testing.T) {
 var _ = Describe("BDD of pod-network-loss experiment", func() {
 
 	// BDD TEST CASE 1
-	Context("Check for litmus components", func() {
+	Context("Check for pod network loss", func() {
 
 		It("Should check for creation of runner pod", func() {
 
@@ -93,10 +92,8 @@ var _ = Describe("BDD of pod-network-loss experiment", func() {
 			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 
 		})
-	})
-	// BDD for checking chaosengine Verdict
-	Context("Check for chaos engine verdict", func() {
 
+		// BDD for checking chaosengine Verdict
 		It("Should check for the verdict of experiment", func() {
 
 			testsDetails := types.TestDetails{}
@@ -200,48 +197,6 @@ var _ = Describe("BDD of pod-network-loss experiment", func() {
 		})
 	})
 
-	// BDD for pipeline result update
-	Context("Check for the result update", func() {
-
-		It("Should check for the result updation", func() {
-
-			testsDetails := types.TestDetails{}
-			clients := environment.ClientSets{}
-
-			//Getting kubeConfig and Generate ClientSets
-			By("[PreChaos]: Getting kubeconfig and generate clientset")
-			if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
-				log.Fatalf("Unable to Get the kubeconfig due to %v", err)
-			}
-
-			//Fetching all the default ENV
-			By("[PreChaos]: Fetching all default ENVs")
-			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
-			environment.GetENV(&testsDetails, "pod-network-loss", "go-engine14")
-
-			//Updating the pipeline result table
-			By("Updating the pipeline result table")
-			//Getting chaosengine verdict for experiment test
-			By("Getting Verdict of Chaos Engine for experiment test")
-			ChaosEngineVerdict, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
-			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
-			Expect(ChaosEngineVerdict).NotTo(BeEmpty(), "Fail to get chaos engine verdict, due to {%v}", err)
-
-			//Getting chaosengine verdict for abort test
-			By("Getting Verdict of Chaos Engine for abort test")
-			testsDetails.EngineName = "pod-net-loss-abort"
-			ChaosEngineVerdictForAbort, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
-			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
-			if ChaosEngineVerdictForAbort != "Stopped" {
-				ChaosEngineVerdict = "Fail"
-				klog.Error("Abort chaos test verdict is not Pass")
-			}
-
-			err = pkg.UpdateResultTable("Inject Packet Loss Into Application Pod", ChaosEngineVerdict, &testsDetails)
-			Expect(err).To(BeNil(), "Job Result Updation failed, due to {%v}", err)
-
-		})
-	})
 	// BDD TEST CASE 3
 	Context("Check for litmus components", func() {
 
@@ -303,11 +258,8 @@ var _ = Describe("BDD of pod-network-loss experiment", func() {
 			Expect(err).To(BeNil(), "ChasoResult Verdict check failed, due to {%v}", err)
 
 		})
-	})
 
-	// BDD for checking chaosengine Verdict when the annotation check is set to true
-	Context("Check for chaos engine verdict", func() {
-
+		// BDD for checking chaosengine Verdict when the annotation check is set to true
 		It("Should check for the verdict of experiment", func() {
 
 			testsDetails := types.TestDetails{}
@@ -327,6 +279,61 @@ var _ = Describe("BDD of pod-network-loss experiment", func() {
 			By("Checking the Verdict of Chaos Engine")
 			err = pkg.ChaosEngineVerdict(&testsDetails, clients)
 			Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+		})
+	})
+
+	// BDD for pipeline result update
+	Context("Check for the result update", func() {
+
+		It("Should check for the result updation", func() {
+
+			testsDetails := types.TestDetails{}
+			clients := environment.ClientSets{}
+
+			//Getting kubeConfig and Generate ClientSets
+			By("[PreChaos]: Getting kubeconfig and generate clientset")
+			err := clients.GenerateClientSetFromKubeConfig()
+			Expect(err).To(BeNil(), "Unable to Get the kubeconfig, due to {%v}", err)
+
+			//Fetching all the default ENV
+			By("[PreChaos]: Fetching all default ENVs")
+			klog.Infof("[PreReq]: Getting the ENVs for the %v test", testsDetails.ExperimentName)
+			environment.GetENV(&testsDetails, "pod-network-loss", "go-engine14")
+
+			if testsDetails.UpdateWebsite == "true" {
+				//Updating the pipeline result table
+				By("Updating the pipeline result table")
+				//Getting chaosengine verdict for experiment test
+				By("Getting Verdict of Chaos Engine for experiment test")
+				ChaosEngineVerdict, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
+				Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+				Expect(ChaosEngineVerdict).NotTo(BeEmpty(), "Fail to get chaos engine verdict, due to {%v}", err)
+
+				//Getting chaosengine verdict for abort test
+				By("Getting Verdict of Chaos Engine for abort test")
+				testsDetails.EngineName = "pod-net-loss-abort"
+				ChaosEngineVerdictForAbort, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
+				Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+				if ChaosEngineVerdictForAbort != "Stopped" {
+					ChaosEngineVerdict = "Fail"
+					klog.Error("Abort chaos test verdict is not Pass")
+				}
+
+				//Getting chaosengine verdict for annotation test
+				By("Getting Verdict of Chaos Engine for annotation test")
+				testsDetails.EngineName = "pnloss-annotated"
+				ChaosEngineVerdictForAnnotate, err := pkg.GetChaosEngineVerdict(&testsDetails, clients)
+				Expect(err).To(BeNil(), "ChaosEngine Verdict check failed, due to {%v}", err)
+				if ChaosEngineVerdictForAnnotate != "Pass" {
+					ChaosEngineVerdict = "Fail"
+					klog.Error("Annotation test verdict is not Pass")
+				}
+
+				err = pkg.UpdateResultTable("Inject Packet Loss Into Application Pod", ChaosEngineVerdict, &testsDetails)
+				Expect(err).To(BeNil(), "Job Result Updation failed, due to {%v}", err)
+			} else {
+				klog.Info("[SKIP]: Skip updating the result on website")
+			}
 		})
 	})
 })

--- a/utils/pipeline_status_update.py
+++ b/utils/pipeline_status_update.py
@@ -89,11 +89,14 @@ def fetch_file_content():
     file_content=str(file.decoded_content, 'utf-8')
     content_list = file_content.split('\n')
     totalCoverage= '<a href=\"https://bit.ly/2OLie8t\"><img alt='+coverage+'% src=\"https://progress-bar.dev/'+coverage+'\" /></a>'
-
+    if tag =="ci":
+           version_name = "Version"
+    else:
+           version_name = "Release Version"
     # updating result's table if the table is already present
-    if file_content.find('<table>\n <tr>\n  <th>Pipeline ID</th>\n  <th>Execution Time</th>\n  <th>Release Version</th></tr>\n')>0:
+    if file_content.find('<table>\n <tr>\n  <th>Pipeline ID</th>\n  <th>Execution Time</th>\n  <th>'+version_name+'</th></tr>\n')>0:
         new_pipeline = ' <tr>\n  <td>{}</td>\n  <td>{}</td>\n  <td>{}</td>\n </tr>\n'.format(pipeline_url,time_stamp,tag)
-        index = content_list.index('  <th>Release Version</th></tr>')
+        index = content_list.index('  <th>'+version_name+'</th></tr>')
         content_list.insert(index+2,new_pipeline)
         for line in content_list:
                count += line.count("<tr>")  
@@ -107,10 +110,7 @@ def fetch_file_content():
 
     # creating result's table for first pipeline result entry 
     else:
-        if tag=="ci":
-               updated_file_content =  '<table>\n <tr>\n  <th>Pipeline ID</th>\n  <th>Execution Time</th>\n  <th>Version</th></tr>\n'
-        else:
-               updated_file_content =  '<table>\n <tr>\n  <th>Pipeline ID</th>\n  <th>Execution Time</th>\n  <th>Release Version</th>\n </tr>\n'
+        updated_file_content =  '<table>\n <tr>\n  <th>Pipeline ID</th>\n  <th>Execution Time</th>\n  <th>'+version_name+'</th></tr>\n'
         updated_file_content = updated_file_content + (' <tr>\n  <td>{}</td>\n  <td>{}</td>\n  <td>{}</td>\n </tr>\n'.format(pipeline_url,time_stamp,tag))
         updated_file_content = updated_file_content + '</table>'
         index = len(content_list)


### PR DESCRIPTION
Signed-off-by: udit <udit.gaurav@mayadata.io>

## Analysis Of Current Pipeline Failure

Component level failures:

====================



Invalid app info test:  The ChaosEgine verdict is not patched to Fail for invalid appinfo: The reason could be the time taken to update the Engine verdict.

**[SOLVED]:** _Solved by adding a retry on Verdict check for both ChaosEngine and ChaosResult. Now it will check the verdict for 30sec._



Abort test: It is also Failed for the same reason the verdict is not pathed in the given time. The experiment used is pod cpu hog.

**[TEMPRORY SOLVED]:** _The Chaos Result Verdict is not patching to stopped. This could be due to the limited time available after abort which is used in killing the process and no time left to update the ChaosResult. Used a different experiment(pod-delete) that does not have any task once aborted._



Job cleanup Policy: The pods are getting evicted due to the disk filling. Can be optimized by using 50% or less as the fill percentage.

**[SOLVED]:** _Used pod-delete instead of disk fill._



No issues with the cleanup. Only need to run the cleanup everytime.



Infra Level failures:

===============



1. Needs docker executor in place of Kubernetes executor

 **[UNSOLVED]:** _It is an infra side change._

2.  Node Taint test does not take taint env to run the pipeline.

**[SOLVED]:** _It was due to a bug in the AfterMatch function._

3. In Litmus Cleanup deleting test ns when it is not at all present. We have common cleanup bdds for different pipelines so we need to manage this type of issue. 

**[SOLVED]:** _fixed the cleanup bdd by adding an if condition before deleting the resources._



4. Separate the e2e metrics cleanup to a separate bdd so that it will always run in case of the setup metrics fails.

**[SOLVED]:** _Done by separating out the bdds for setup and cleanup so that the cleanup should work even setup is failed._



Pod Level failures:

==============


1. pod cpu hog: 

 i) Handle the chaos kill command as the default one does not work. **[SOLVED]:** _Added default Chaos Kill command_

 ii) Same issue for patching the verdict in a failed case is more. **[UNSOLVED]:** _Needed to be solved from the experiment side_

 iii) Annotation check is failing because of the same reason that is verdict patching. **[UNSOLVED]:** _Needed to be solved from the experiment side_



2. pod delete: Lib image is not required. **[SOLVED]** _Removed adding lib image in the engine.yaml_



3. Pod io stress is having a known issue that the container is not stopping after chaos and the experiment fails. **.[UNSOLVED]**



4. pod memory hog: same as pod cpu hog. Need to change the Chaos Kill command, Verdict patching. [**SOLVED]:** _Same as pod cpu hog_



5. Network latency validation sometimes fails as 100% packet got received which fails the bdd. Need a retry here or sending more packets.

**[SOLVED]:** The default latency (which is 2000) was less. When a larger value is provided then the network latency got verified.



6. Fail to delete test ns: - Do we create such ns? If no then delete it. 

**[SOLVED]:** _Updated cleanup bdd._