### PR TITLE
eq(1) selector is not needed

### DIFF
--- a/Cypress/cypress/integration/Parallel_Tests/Create_Workflow/template.spec.js
+++ b/Cypress/cypress/integration/Parallel_Tests/Create_Workflow/template.spec.js
@@ -87,7 +87,7 @@ describe("Testing the workflow creation wizard using Templates", () => {
 					.should("include.text", workflows.nonRecurringworkflowName); // Matching Workflow Name Regex
 				cy.wrap($div).find("td").eq(1).should("have.text", "Self-Agent"); // Matching Target Agent
 			});
-		cy.get("[data-cy=browseScheduleOptions]").eq(1).click();
+		cy.get("[data-cy=browseScheduleOptions]").click();
 		cy.get("[data-cy=saveTemplate]")
 			.eq(0)
 			.should("have.text", "Save Template")

--- a/Cypress/cypress/integration/Parallel_Tests/Create_Workflow/template.spec.js
+++ b/Cypress/cypress/integration/Parallel_Tests/Create_Workflow/template.spec.js
@@ -87,7 +87,7 @@ describe("Testing the workflow creation wizard using Templates", () => {
 					.should("include.text", workflows.nonRecurringworkflowName); // Matching Workflow Name Regex
 				cy.wrap($div).find("td").eq(1).should("have.text", "Self-Agent"); // Matching Target Agent
 			});
-		cy.get("[data-cy=browseScheduleOptions]").click();
+		cy.get("[data-cy=browseScheduleOptions]").eq(0).click();
 		cy.get("[data-cy=saveTemplate]")
 			.eq(0)
 			.should("have.text", "Save Template")


### PR DESCRIPTION
The test for saving the workflow often fails when the cypress server looks for eq(1). 
Don't think it is needed. The test runs fine without it.