### PR TITLE
[Migrate]: Pod level pipeline from self hosted runner to shared runner

### DIFF
--- a/.github/workflows/pod-level-pipeline.yml
+++ b/.github/workflows/pod-level-pipeline.yml
@@ -3,8 +3,10 @@ name: Pod-Level-Pipeline
 on:
   workflow_dispatch:
     inputs:
-      e2eTestImage:
-        default: "litmuschaos/litmus-e2e:ci"
+      e2eTestRepo:
+        default: "litmuschaos/litmus-e2e"
+      e2eTestBranch:
+        default: "master" 
       goExperimentImage:
         default: "litmuschaos/go-runner:ci"
       libImage:
@@ -21,109 +23,53 @@ on:
         default: "Always"
       experimentImagePullPolicy:
         default: "Always"
-      chaosServiceAccount:
-        default: ""
-
-defaults:
-  run:
-    working-directory: /go/src
 
 jobs:
-  ### Setup Litmus
 
-  Setup_Litmus_Infra:
-    container:
-      image: "${{ github.event.inputs.e2eTestImage }}"
-      volumes:
-        - /home/ubuntu/.kube:/root/.kube
-        - /home/ubuntu/.aws:/root/.aws
-        - /etc/kubernetes:/etc/kubernetes
-      env:
-        OPERATOR_IMAGE: "${{ github.event.inputs.operatorImage }}"
-        OPERATOR_NAME: "${{ github.event.inputs.operatorName }}"
-        RUNNER_IMAGE: "${{ github.event.inputs.runnerImage }}"
-        IMAGE_PULL_POLICY: "${{ github.event.inputs.imagePullPolicy }}"
-        KUBECONFIG: /root/.kube/config
-
-    runs-on: [self-hosted, pod-level]
-    ## Changing the working directory to image path we provided
-    ## As the default path is repository checkout path.
+  Network_Chaos_Test:
+    if: always()
+    runs-on: ubuntu-latest
+    env:
+      OPERATOR_IMAGE: "${{ github.event.inputs.operatorImage }}"
+      OPERATOR_NAME: "${{ github.event.inputs.operatorName }}"
+      RUNNER_IMAGE: "${{ github.event.inputs.runnerImage }}"
+      IMAGE_PULL_POLICY: "${{ github.event.inputs.imagePullPolicy }}"        
+      GO_EXPERIMENT_IMAGE: "${{ github.event.inputs.goExperimentImage }}"
+      LIB_IMAGE: "${{ github.event.inputs.libImage }}"
+      EXPERIMENT_IMAGE_PULL_POLICY: "${{ github.event.inputs.experimentImagePullPolicy }}"
+      CHAOS_NAMESPACE: "${{ github.event.inputs.chaosNamespace }}"
+      APP_NS: "${{ github.event.inputs.chaosNamespace }}"
+      CHAOS_SERVICE_ACCOUNT: "${{ github.event.inputs.chaosServiceAccount }}"
+      UPDATE_WEBSITE: "false"
+      KUBECONFIG: /etc/rancher/k3s/k3s.yaml   
+      POD_LEVEL: "true"      
+    
     steps:
+    
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.16'
+
+      - uses: actions/checkout@v2
+        with:
+          repository: '${{ github.event.inputs.e2eTestRepo }}'
+          ref: '${{ github.event.inputs.e2eTestBranch }}'      
+    
+      - name: Installing Prerequisites (K3S Cluster)
+        run: |
+          curl -sfL https://get.k3s.io | sh -s - --docker --write-kubeconfig-mode 664
+          kubectl wait node --all --for condition=ready --timeout=90s
+          kubectl get nodes
+          
       - name: Litmus Infra Setup In Cluster-1
+        if: ${{ always() }}      
         run: |
           make build-litmus
 
-  ### Setup App
-  Setup_App_Deployment:
-    needs: Setup_Litmus_Infra
-    container:
-      image: "${{ github.event.inputs.e2eTestImage }}"
-      volumes:
-        - /home/ubuntu/.kube:/root/.kube
-        - /home/ubuntu/.aws:/root/.aws
-        - /etc/kubernetes:/etc/kubernetes
-      env:
-        KUBECONFIG: /root/.kube/config
-
-    runs-on: [self-hosted, pod-level]
-    steps:
       - name: Deploy App In Cluster-1
+        if: ${{ always() }}      
         run: make app-deploy
-
-    ## TODO: Make use of app liveness check and aux app
-    # - name: Liveness In Cluster-1
-    #   if: ${{ always() }}
-    #   run: make liveness
-
-    # - name: Auxiliary App In Cluster-1
-    #   if: ${{ always() }}
-    #   run: make auxiliary-app
-
-  ### Runing Pod Level Tests
-
-  Pod_Level_Test:
-    needs: Setup_App_Deployment
-    if: always()
-    container:
-      image: "${{ github.event.inputs.e2eTestImage }}"
-      volumes:
-        - /home/ubuntu/.kube:/root/.kube
-        - /home/ubuntu/.aws:/root/.aws
-        - /etc/kubernetes:/etc/kubernetes
-      env:
-        GO_EXPERIMENT_IMAGE: "${{ github.event.inputs.goExperimentImage }}"
-        LIB_IMAGE: "${{ github.event.inputs.libImage }}"
-        EXPERIMENT_IMAGE_PULL_POLICY: "${{ github.event.inputs.experimentImagePullPolicy }}"
-        CHAOS_NAMESPACE: "${{ github.event.inputs.chaosNamespace }}"
-        CHAOS_SERVICE_ACCOUNT: "${{ github.event.inputs.chaosServiceAccount }}"
-        UPDATE_WEBSITE: "false"
-        KUBECONFIG: /root/.kube/config
-
-    runs-on: [self-hosted, pod-level]
-    steps:
-      - name: TCID-EC2-GENERIC-APP-POD-DELETE
-        run: make pod-delete
-
-      - name: TCID-EC2-GENERIC-APP-CONTAINER-KILL
-        if: ${{ always() }}
-        run: make container-kill
-
-      - name: TCID-EC2-GENERIC-APP-POD-CPU-HOG
-        if: ${{ always() }}
-        run: make pod-cpu-hog
-
-      - name: TCID-EC2-GENERIC-APP-POD-MEMORY-HOG
-        if: ${{ always() }}
-        run: make pod-memory-hog
-
-      - name: TCID-EC2-GENERIC-APP-POD-CPU-HOG
-        if: ${{ always() }}
-        run: make pod-cpu-hog-exec
-
-      - name: TCID-EC2-GENERIC-APP-POD-MEMORY-HOG
-        if: ${{ always() }}
-        run: make pod-memory-hog-exec        
-
+    
       - name: TCID-EC2-GENERIC-APP-POD-NETWORK-CORRUPTION
         if: ${{ always() }}
         run: make pod-network-corruption
@@ -139,6 +85,93 @@ jobs:
       - name: TCID-EC2-GENERIC-APP-POD-NETWORK-DUPLICATION
         if: ${{ always() }}
         run: make pod-network-duplication
+        
+      - name: "[Debug]: check chaos resources"
+        if: ${{ failure() }}
+        continue-on-error: true
+        run: |
+          bash <(curl -s https://raw.githubusercontent.com/litmuschaos/litmus-e2e/master/build/debug.sh)
+          
+      - name: "[Debug]: check operator logs"
+        if: ${{ failure() }}
+        continue-on-error: true
+        run: |      
+          operator_name=$(kubectl get pods -n litmus -l app.kubernetes.io/component=operator --no-headers | awk '{print$1}')
+          kubectl logs $operator_name -n litmus > logs.txt
+          cat logs.txt        
+        
+      - name: Application Cleanup
+        if: ${{ always() }}      
+        run: make app-cleanup
+
+      - name: Litmus Cleanup
+        if: ${{ always() }}      
+        run: make litmus-cleanup 
+        
+      - name: Deleting K3S cluster
+        if: always()
+        run: /usr/local/bin/k3s-uninstall.sh
+        
+  Stress_Chaos_Test:
+    if: always()
+    runs-on: ubuntu-latest
+    env:
+      OPERATOR_IMAGE: "${{ github.event.inputs.operatorImage }}"
+      OPERATOR_NAME: "${{ github.event.inputs.operatorName }}"
+      RUNNER_IMAGE: "${{ github.event.inputs.runnerImage }}"
+      IMAGE_PULL_POLICY: "${{ github.event.inputs.imagePullPolicy }}"        
+      GO_EXPERIMENT_IMAGE: "${{ github.event.inputs.goExperimentImage }}"
+      LIB_IMAGE: "${{ github.event.inputs.libImage }}"
+      EXPERIMENT_IMAGE_PULL_POLICY: "${{ github.event.inputs.experimentImagePullPolicy }}"
+      CHAOS_NAMESPACE: "${{ github.event.inputs.chaosNamespace }}"
+      APP_NS: "${{ github.event.inputs.chaosNamespace }}"
+      CHAOS_SERVICE_ACCOUNT: "${{ github.event.inputs.chaosServiceAccount }}"
+      UPDATE_WEBSITE: "false"
+      KUBECONFIG: /etc/rancher/k3s/k3s.yaml   
+      POD_LEVEL: "true"      
+    
+    steps:
+    
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.16'
+
+      - uses: actions/checkout@v2
+        with:
+          repository: '${{ github.event.inputs.e2eTestRepo }}'
+          ref: '${{ github.event.inputs.e2eTestBranch }}'      
+    
+
+      - name: Installing Prerequisites (K3S Cluster)
+        run: |
+          curl -sfL https://get.k3s.io | sh -s - --docker --write-kubeconfig-mode 664
+          kubectl wait node --all --for condition=ready --timeout=90s
+          kubectl get nodes
+          
+      - name: Litmus Infra Setup In Cluster-1
+        if: ${{ always() }}      
+        run: |
+          make build-litmus
+
+      - name: Deploy App In Cluster-1
+        if: ${{ always() }}      
+        run: make app-deploy
+    
+      - name: TCID-EC2-GENERIC-APP-POD-CPU-HOG
+        if: ${{ always() }}
+        run: make pod-cpu-hog
+
+      - name: TCID-EC2-GENERIC-APP-POD-MEMORY-HOG
+        if: ${{ always() }}
+        run: make pod-memory-hog
+
+      - name: TCID-EC2-GENERIC-APP-POD-CPU-HOG-EXEC
+        if: ${{ always() }}
+        run: make pod-cpu-hog-exec
+
+      - name: TCID-EC2-GENERIC-APP-POD-MEMORY-HOG-EXEC
+        if: ${{ always() }}
+        run: make pod-memory-hog-exec        
 
       - name: TCID-EC2-GENERIC-APP-POD-IO-STRESS
         if: ${{ always() }}
@@ -147,30 +180,226 @@ jobs:
       - name: TCID-EC2-GENERIC-APP-DISK-FILL
         if: ${{ always() }}
         run: make disk-fill
+        
+      - name: "[Debug]: check chaos resources"
+        if: ${{ failure() }}
+        continue-on-error: true
+        run: |
+          bash <(curl -s https://raw.githubusercontent.com/litmuschaos/litmus-e2e/master/build/debug.sh)
+          
+      - name: "[Debug]: check operator logs"
+        if: ${{ failure() }}
+        continue-on-error: true
+        run: |      
+          operator_name=$(kubectl get pods -n litmus -l app.kubernetes.io/component=operator --no-headers | awk '{print$1}')
+          kubectl logs $operator_name -n litmus > logs.txt
+          cat logs.txt        
+        
+      - name: Application Cleanup
+        if: ${{ always() }}      
+        run: make app-cleanup
+
+      - name: Litmus Cleanup
+        if: ${{ always() }}      
+        run: make litmus-cleanup         
+        
+      - name: Deleting K3S cluster
+        if: always()
+        run: /usr/local/bin/k3s-uninstall.sh   
+
+  Container_Kill_Test:
+    if: always()
+    runs-on: ubuntu-latest
+    env:
+      OPERATOR_IMAGE: "${{ github.event.inputs.operatorImage }}"
+      OPERATOR_NAME: "${{ github.event.inputs.operatorName }}"
+      RUNNER_IMAGE: "${{ github.event.inputs.runnerImage }}"
+      IMAGE_PULL_POLICY: "${{ github.event.inputs.imagePullPolicy }}"        
+      GO_EXPERIMENT_IMAGE: "${{ github.event.inputs.goExperimentImage }}"
+      LIB_IMAGE: "${{ github.event.inputs.libImage }}"
+      EXPERIMENT_IMAGE_PULL_POLICY: "${{ github.event.inputs.experimentImagePullPolicy }}"
+      CHAOS_NAMESPACE: "${{ github.event.inputs.chaosNamespace }}"
+      APP_NS: "${{ github.event.inputs.chaosNamespace }}"
+      CHAOS_SERVICE_ACCOUNT: "${{ github.event.inputs.chaosServiceAccount }}"
+      UPDATE_WEBSITE: "false"
+      KUBECONFIG: /etc/rancher/k3s/k3s.yaml   
+      POD_LEVEL: "true"      
+    
+    steps:
+    
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.16'
+
+      - uses: actions/checkout@v2
+        with:
+          repository: '${{ github.event.inputs.e2eTestRepo }}'
+          ref: '${{ github.event.inputs.e2eTestBranch }}'      
+    
+      - name: Installing Prerequisites (K3S Cluster)
+        run: |
+          curl -sfL https://get.k3s.io | sh -s - --docker --write-kubeconfig-mode 664
+          kubectl wait node --all --for condition=ready --timeout=90s
+          kubectl get nodes
+          
+      - name: Litmus Infra Setup In Cluster-1
+        if: ${{ always() }}      
+        run: |
+          make build-litmus
+
+      - name: Deploy App In Cluster-1
+        if: ${{ always() }}      
+        run: make app-deploy
+    
+      - name: TCID-EC2-GENERIC-APP-CONTAINER-KILL
+        if: ${{ always() }}
+        run: make container-kill
+        
+      - name: "[Debug]: check chaos resources"
+        if: ${{ failure() }}
+        continue-on-error: true
+        run: |
+          bash <(curl -s https://raw.githubusercontent.com/litmuschaos/litmus-e2e/master/build/debug.sh)
+          
+      - name: "[Debug]: check operator logs"
+        if: ${{ failure() }}
+        continue-on-error: true
+        run: |      
+          operator_name=$(kubectl get pods -n litmus -l app.kubernetes.io/component=operator --no-headers | awk '{print$1}')
+          kubectl logs $operator_name -n litmus > logs.txt
+          cat logs.txt        
+        
+      - name: Application Cleanup
+        if: ${{ always() }}      
+        run: make app-cleanup
+
+      - name: Litmus Cleanup
+        if: ${{ always() }}      
+        run: make litmus-cleanup      
+        
+      - name: Deleting K3S cluster
+        if: always()
+        run: /usr/local/bin/k3s-uninstall.sh        
+
+  Pod_Delete_Test:
+    if: always()
+    runs-on: ubuntu-latest
+    env:
+      OPERATOR_IMAGE: "${{ github.event.inputs.operatorImage }}"
+      OPERATOR_NAME: "${{ github.event.inputs.operatorName }}"
+      RUNNER_IMAGE: "${{ github.event.inputs.runnerImage }}"
+      IMAGE_PULL_POLICY: "${{ github.event.inputs.imagePullPolicy }}"        
+      GO_EXPERIMENT_IMAGE: "${{ github.event.inputs.goExperimentImage }}"
+      LIB_IMAGE: "${{ github.event.inputs.libImage }}"
+      EXPERIMENT_IMAGE_PULL_POLICY: "${{ github.event.inputs.experimentImagePullPolicy }}"
+      CHAOS_NAMESPACE: "${{ github.event.inputs.chaosNamespace }}"
+      APP_NS: "${{ github.event.inputs.chaosNamespace }}"
+      CHAOS_SERVICE_ACCOUNT: "${{ github.event.inputs.chaosServiceAccount }}"
+      UPDATE_WEBSITE: "false"
+      KUBECONFIG: /etc/rancher/k3s/k3s.yaml
+      POD_LEVEL: "true"      
+    
+    steps:
+    
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.16'
+
+      - uses: actions/checkout@v2
+        with:
+          repository: '${{ github.event.inputs.e2eTestRepo }}'
+          ref: '${{ github.event.inputs.e2eTestBranch }}'      
+    
+      - name: Installing Prerequisites (K3S Cluster)
+        run: |
+          curl -sfL https://get.k3s.io | sh -s - --docker --write-kubeconfig-mode 664
+          kubectl wait node --all --for condition=ready --timeout=90s
+          kubectl get nodes
+          
+      - name: Litmus Infra Setup In Cluster-1
+        if: ${{ always() }}      
+        run: |
+          make build-litmus
+
+      - name: Deploy App In Cluster-1
+        if: ${{ always() }}      
+        run: make app-deploy
+    
+      - name: TCID-EC2-GENERIC-APP-POD-DELETE
+        if: ${{ always() }}      
+        run: make pod-delete
+        
+      - name: "[Debug]: check chaos resources"
+        if: ${{ failure() }}
+        continue-on-error: true
+        run: |
+          bash <(curl -s https://raw.githubusercontent.com/litmuschaos/litmus-e2e/master/build/debug.sh)
+          
+      - name: "[Debug]: check operator logs"
+        if: ${{ failure() }}
+        continue-on-error: true
+        run: |      
+          operator_name=$(kubectl get pods -n litmus -l app.kubernetes.io/component=operator --no-headers | awk '{print$1}')
+          kubectl logs $operator_name -n litmus > logs.txt
+          cat logs.txt        
+        
+      - name: Application Cleanup
+        if: ${{ always() }}      
+        run: make app-cleanup
+
+      - name: Litmus Cleanup
+        if: ${{ always() }}      
+        run: make litmus-cleanup      
+        
+      - name: Deleting K3S cluster
+        if: always()
+        run: /usr/local/bin/k3s-uninstall.sh        
+
 
   ### Runing Experiment Tunables
-  Experiment_Tunables:
-    needs: Setup_App_Deployment
+  PAP_100_Mode_Parallel:
     if: always()
-    container:
-      image: "${{ github.event.inputs.e2eTestImage }}"
-      volumes:
-        - /home/ubuntu/.kube:/root/.kube
-        - /home/ubuntu/.aws:/root/.aws
-        - /etc/kubernetes:/etc/kubernetes
-      env:
-        GO_EXPERIMENT_IMAGE: "${{ github.event.inputs.goExperimentImage }}"
-        LIB_IMAGE: "${{ github.event.inputs.libImage }}"
-        EXPERIMENT_IMAGE_PULL_POLICY: "${{ github.event.inputs.experimentImagePullPolicy }}"
-        CHAOS_NAMESPACE: "${{ github.event.inputs.expTunnableNS }}"
-        CHAOS_SERVICE_ACCOUNT: "${{ github.event.inputs.chaosServiceAccount }}"
-        APP_NS: "${{ github.event.inputs.expTunnableNS }}"
-        APP_LABEL: "app=nginx"
-        UPDATE_WEBSITE: "false"
-        KUBECONFIG: /root/.kube/config
-
-    runs-on: [self-hosted, pod-level-exp-tunable]
+    runs-on: ubuntu-latest
+    env:
+      GO_EXPERIMENT_IMAGE: "${{ github.event.inputs.goExperimentImage }}"
+      LIB_IMAGE: "${{ github.event.inputs.libImage }}"
+      EXPERIMENT_IMAGE_PULL_POLICY: "${{ github.event.inputs.experimentImagePullPolicy }}"
+      CHAOS_NAMESPACE: "${{ github.event.inputs.expTunnableNS }}"
+      CHAOS_SERVICE_ACCOUNT: "${{ github.event.inputs.chaosServiceAccount }}"
+      APP_NS: "${{ github.event.inputs.expTunnableNS }}"
+      APP_LABEL: "app=nginx"
+      UPDATE_WEBSITE: "false"
+      KUBECONFIG: /etc/rancher/k3s/k3s.yaml
+      OPERATOR_IMAGE: "${{ github.event.inputs.operatorImage }}"
+      OPERATOR_NAME: "${{ github.event.inputs.operatorName }}"
+      RUNNER_IMAGE: "${{ github.event.inputs.runnerImage }}"
+      IMAGE_PULL_POLICY: "${{ github.event.inputs.imagePullPolicy }}"  
+      POD_LEVEL: "true"      
+    
     steps:
+
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.16'
+
+      - uses: actions/checkout@v2
+        with:
+          repository: '${{ github.event.inputs.e2eTestRepo }}'
+          ref: '${{ github.event.inputs.e2eTestBranch }}'      
+
+      - name: Installing Prerequisites (K3S Cluster)
+        run: |
+          curl -sfL https://get.k3s.io | sh -s - --docker --write-kubeconfig-mode 664
+          kubectl wait node --all --for condition=ready --timeout=90s
+          kubectl get nodes
+          
+      - name: Litmus Infra Setup In Cluster-1
+        run: |
+          make build-litmus
+
+      - name: Deploy App In Cluster-1
+        run: make app-deploy
+        
       - name: Create Namespace and deploy Application
         run: |
           kubectl create ns ${CHAOS_NAMESPACE}
@@ -181,13 +410,194 @@ jobs:
       - name: TCID-EC2-GENERIC-APP-POD-AFFECTED-PERCENTAGE-TON-PARALLEL
         run: make pod-affected-perc-ton-parallel
 
+      - name: Experiment Tunables Cleanup
+        if: ${{ always() }}
+        run: |
+          kubectl delete chaosengines --all -n ${CHAOS_NAMESPACE}
+          kubectl delete ns ${CHAOS_NAMESPACE}
+          
+      - name: "[Debug]: check chaos resources"
+        if: ${{ failure() }}
+        continue-on-error: true
+        run: |
+          bash <(curl -s https://raw.githubusercontent.com/litmuschaos/litmus-e2e/master/build/debug.sh)
+          
+      - name: "[Debug]: check operator logs"
+        if: ${{ failure() }}
+        continue-on-error: true
+        run: |      
+          operator_name=$(kubectl get pods -n litmus -l app.kubernetes.io/component=operator --no-headers | awk '{print$1}')
+          kubectl logs $operator_name -n litmus > logs.txt
+          cat logs.txt          
+          
+      - name: Application Cleanup
+        if: ${{ always() }}      
+        run: make app-cleanup
+
+      - name: Litmus Cleanup
+        if: ${{ always() }}      
+        run: make litmus-cleanup    
+        
+      - name: Deleting K3S cluster
+        if: always()
+        run: /usr/local/bin/k3s-uninstall.sh        
+
+  ### Runing Experiment Tunables
+  PAP_100_Mode_Serial:
+    if: always()
+    runs-on: ubuntu-latest
+    env:
+      GO_EXPERIMENT_IMAGE: "${{ github.event.inputs.goExperimentImage }}"
+      LIB_IMAGE: "${{ github.event.inputs.libImage }}"
+      EXPERIMENT_IMAGE_PULL_POLICY: "${{ github.event.inputs.experimentImagePullPolicy }}"
+      CHAOS_NAMESPACE: "${{ github.event.inputs.expTunnableNS }}"
+      CHAOS_SERVICE_ACCOUNT: "${{ github.event.inputs.chaosServiceAccount }}"
+      APP_NS: "${{ github.event.inputs.expTunnableNS }}"
+      APP_LABEL: "app=nginx"
+      UPDATE_WEBSITE: "false"
+      KUBECONFIG: /etc/rancher/k3s/k3s.yaml
+      OPERATOR_IMAGE: "${{ github.event.inputs.operatorImage }}"
+      OPERATOR_NAME: "${{ github.event.inputs.operatorName }}"
+      RUNNER_IMAGE: "${{ github.event.inputs.runnerImage }}"
+      IMAGE_PULL_POLICY: "${{ github.event.inputs.imagePullPolicy }}"
+      POD_LEVEL: "true"      
+    
+    steps:
+
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.16'
+
+      - uses: actions/checkout@v2
+        with:
+          repository: '${{ github.event.inputs.e2eTestRepo }}'
+          ref: '${{ github.event.inputs.e2eTestBranch }}'      
+
+      - name: Installing Prerequisites (K3S Cluster)
+        run: |
+          curl -sfL https://get.k3s.io | sh -s - --docker --write-kubeconfig-mode 664
+          kubectl wait node --all --for condition=ready --timeout=90s
+          kubectl get nodes
+          
+      - name: Litmus Infra Setup In Cluster-1
+        run: |
+          make build-litmus
+
+      - name: Deploy App In Cluster-1
+        run: make app-deploy
+        
+      - name: Create Namespace and deploy Application
+        run: |
+          kubectl create ns ${CHAOS_NAMESPACE}
+          kubectl create deploy nginx --image=nginx:alpine -n ${CHAOS_NAMESPACE}
+          kubectl wait --for=condition=Ready pods --all --namespace ${CHAOS_NAMESPACE} --timeout=90s
+          kubectl annotate deploy/nginx litmuschaos.io/chaos="true" -n ${CHAOS_NAMESPACE} --overwrite
+          
       - name: TCID-EC2-GENERIC-APP-POD-AFFECTED-PERCENTAGE-TON-SERIES
         if: ${{ always() }}
         run: make pod-affected-perc-ton-series
 
+      - name: Experiment Tunables Cleanup
+        if: ${{ always() }}
+        run: |
+          kubectl delete chaosengines --all -n ${CHAOS_NAMESPACE}
+          kubectl delete ns ${CHAOS_NAMESPACE}
+          
+      - name: "[Debug]: check chaos resources"
+        if: ${{ failure() }}
+        continue-on-error: true
+        run: |
+          bash <(curl -s https://raw.githubusercontent.com/litmuschaos/litmus-e2e/master/build/debug.sh)
+          
+      - name: "[Debug]: check operator logs"
+        if: ${{ failure() }}
+        continue-on-error: true
+        run: |      
+          operator_name=$(kubectl get pods -n litmus -l app.kubernetes.io/component=operator --no-headers | awk '{print$1}')
+          kubectl logs $operator_name -n litmus > logs.txt
+          cat logs.txt          
+          
+      - name: Application Cleanup
+        if: ${{ always() }}      
+        run: make app-cleanup
+
+      - name: Litmus Cleanup
+        if: ${{ always() }}      
+        run: make litmus-cleanup       
+        
+      - name: Deleting K3S cluster
+        if: always()
+        run: /usr/local/bin/k3s-uninstall.sh        
+
+
+  ### Runing Experiment Tunables
+  Multiple_App_Deploy:
+    if: always()
+    runs-on: ubuntu-latest
+    env:
+      GO_EXPERIMENT_IMAGE: "${{ github.event.inputs.goExperimentImage }}"
+      LIB_IMAGE: "${{ github.event.inputs.libImage }}"
+      EXPERIMENT_IMAGE_PULL_POLICY: "${{ github.event.inputs.experimentImagePullPolicy }}"
+      CHAOS_NAMESPACE: "${{ github.event.inputs.expTunnableNS }}"
+      CHAOS_SERVICE_ACCOUNT: "${{ github.event.inputs.chaosServiceAccount }}"
+      APP_NS: "${{ github.event.inputs.expTunnableNS }}"
+      APP_LABEL: "app=nginx"
+      UPDATE_WEBSITE: "false"
+      KUBECONFIG: /etc/rancher/k3s/k3s.yaml
+      OPERATOR_IMAGE: "${{ github.event.inputs.operatorImage }}"
+      OPERATOR_NAME: "${{ github.event.inputs.operatorName }}"
+      RUNNER_IMAGE: "${{ github.event.inputs.runnerImage }}"
+      IMAGE_PULL_POLICY: "${{ github.event.inputs.imagePullPolicy }}" 
+      POD_LEVEL: "true"      
+    
+    steps:
+
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.16'
+
+      - uses: actions/checkout@v2
+        with:
+          repository: '${{ github.event.inputs.e2eTestRepo }}'
+          ref: '${{ github.event.inputs.e2eTestBranch }}'      
+
+      - name: Installing Prerequisites (K3S Cluster)
+        run: |
+          curl -sfL https://get.k3s.io | sh -s - --docker --write-kubeconfig-mode 664
+          kubectl wait node --all --for condition=ready --timeout=90s
+          kubectl get nodes
+          
+      - name: Litmus Infra Setup In Cluster-1
+        run: |
+          make build-litmus
+
+      - name: Deploy App In Cluster-1
+        run: make app-deploy
+        
+      - name: Create Namespace and deploy Application
+        run: |
+          kubectl create ns ${CHAOS_NAMESPACE}
+          kubectl create deploy nginx --image=nginx:alpine -n ${CHAOS_NAMESPACE}
+          kubectl wait --for=condition=Ready pods --all --namespace ${CHAOS_NAMESPACE} --timeout=90s
+          kubectl annotate deploy/nginx litmuschaos.io/chaos="true" -n ${CHAOS_NAMESPACE} --overwrite
+
       - name: TCID-EC2-GENERIC-APP-MULTIPLE-APP-DEPLOY
         if: ${{ always() }}
         run: make multiple-app-deploy
+        
+      - name: "[Debug]: check chaos resources"
+        if: ${{ failure() }}
+        continue-on-error: true
+        run: |
+          bash <(curl -s https://raw.githubusercontent.com/litmuschaos/litmus-e2e/master/build/debug.sh)
+          
+      - name: "[Debug]: check operator logs"
+        if: ${{ failure() }}
+        continue-on-error: true
+        run: |      
+          operator_name=$(kubectl get pods -n litmus -l app.kubernetes.io/component=operator --no-headers | awk '{print$1}')
+          kubectl logs $operator_name -n litmus > logs.txt
+          cat logs.txt        
 
       - name: Experiment Tunables Cleanup
         if: ${{ always() }}
@@ -195,41 +605,11 @@ jobs:
           kubectl delete chaosengines --all -n ${CHAOS_NAMESPACE}
           kubectl delete ns ${CHAOS_NAMESPACE}
 
-  ### App Cleanup
-
-  App_Cleanup:
-    needs: [Pod_Level_Test,Experiment_Tunables]
-    if: always()
-    container:
-      image: "${{ github.event.inputs.e2eTestImage }}"
-      volumes:
-        - /home/ubuntu/.kube:/root/.kube
-        - /home/ubuntu/.aws:/root/.aws
-        - /etc/kubernetes:/etc/kubernetes
-      env:
-        KUBECONFIG: /root/.kube/config
-
-    runs-on: [self-hosted, pod-level]
-    steps:
-      - name: Application Cleanup
-        run: make app-cleanup
-
-  ### Litmus Cleanup
-
-  Litmus_Cleanup:
-    needs: App_Cleanup
-    if: always()
-    container:
-      image: "${{ github.event.inputs.e2eTestImage }}"
-      volumes:
-        - /home/ubuntu/.kube:/root/.kube
-        - /home/ubuntu/.aws:/root/.aws
-        - /etc/kubernetes:/etc/kubernetes
-      env:
-        KUBECONFIG: /root/.kube/config
-        POD_LEVEL: "true"
-
-    runs-on: [self-hosted, pod-level]
-    steps:
       - name: Litmus Cleanup
-        run: make litmus-cleanup
+        if: ${{ always() }}      
+        run: make litmus-cleanup 
+        
+      - name: Deleting K3S cluster
+        if: always()
+        run: /usr/local/bin/k3s-uninstall.sh        
+

--- a/.github/workflows/pod-level-pipeline.yml
+++ b/.github/workflows/pod-level-pipeline.yml
@@ -21,8 +21,8 @@ on:
         default: "litmus"
       imagePullPolicy:
         default: "Always"
-      experimentImagePullPolicy:
-        default: "Always"
+      chaosServiceAccount:
+        default: ""
 
 jobs:
 
@@ -31,12 +31,10 @@ jobs:
     runs-on: ubuntu-latest
     env:
       OPERATOR_IMAGE: "${{ github.event.inputs.operatorImage }}"
-      OPERATOR_NAME: "${{ github.event.inputs.operatorName }}"
       RUNNER_IMAGE: "${{ github.event.inputs.runnerImage }}"
       IMAGE_PULL_POLICY: "${{ github.event.inputs.imagePullPolicy }}"        
       GO_EXPERIMENT_IMAGE: "${{ github.event.inputs.goExperimentImage }}"
       LIB_IMAGE: "${{ github.event.inputs.libImage }}"
-      EXPERIMENT_IMAGE_PULL_POLICY: "${{ github.event.inputs.experimentImagePullPolicy }}"
       CHAOS_NAMESPACE: "${{ github.event.inputs.chaosNamespace }}"
       APP_NS: "${{ github.event.inputs.chaosNamespace }}"
       CHAOS_SERVICE_ACCOUNT: "${{ github.event.inputs.chaosServiceAccount }}"
@@ -117,12 +115,10 @@ jobs:
     runs-on: ubuntu-latest
     env:
       OPERATOR_IMAGE: "${{ github.event.inputs.operatorImage }}"
-      OPERATOR_NAME: "${{ github.event.inputs.operatorName }}"
       RUNNER_IMAGE: "${{ github.event.inputs.runnerImage }}"
       IMAGE_PULL_POLICY: "${{ github.event.inputs.imagePullPolicy }}"        
       GO_EXPERIMENT_IMAGE: "${{ github.event.inputs.goExperimentImage }}"
       LIB_IMAGE: "${{ github.event.inputs.libImage }}"
-      EXPERIMENT_IMAGE_PULL_POLICY: "${{ github.event.inputs.experimentImagePullPolicy }}"
       CHAOS_NAMESPACE: "${{ github.event.inputs.chaosNamespace }}"
       APP_NS: "${{ github.event.inputs.chaosNamespace }}"
       CHAOS_SERVICE_ACCOUNT: "${{ github.event.inputs.chaosServiceAccount }}"
@@ -212,12 +208,10 @@ jobs:
     runs-on: ubuntu-latest
     env:
       OPERATOR_IMAGE: "${{ github.event.inputs.operatorImage }}"
-      OPERATOR_NAME: "${{ github.event.inputs.operatorName }}"
       RUNNER_IMAGE: "${{ github.event.inputs.runnerImage }}"
       IMAGE_PULL_POLICY: "${{ github.event.inputs.imagePullPolicy }}"        
       GO_EXPERIMENT_IMAGE: "${{ github.event.inputs.goExperimentImage }}"
       LIB_IMAGE: "${{ github.event.inputs.libImage }}"
-      EXPERIMENT_IMAGE_PULL_POLICY: "${{ github.event.inputs.experimentImagePullPolicy }}"
       CHAOS_NAMESPACE: "${{ github.event.inputs.chaosNamespace }}"
       APP_NS: "${{ github.event.inputs.chaosNamespace }}"
       CHAOS_SERVICE_ACCOUNT: "${{ github.event.inputs.chaosServiceAccount }}"
@@ -286,12 +280,10 @@ jobs:
     runs-on: ubuntu-latest
     env:
       OPERATOR_IMAGE: "${{ github.event.inputs.operatorImage }}"
-      OPERATOR_NAME: "${{ github.event.inputs.operatorName }}"
       RUNNER_IMAGE: "${{ github.event.inputs.runnerImage }}"
       IMAGE_PULL_POLICY: "${{ github.event.inputs.imagePullPolicy }}"        
       GO_EXPERIMENT_IMAGE: "${{ github.event.inputs.goExperimentImage }}"
       LIB_IMAGE: "${{ github.event.inputs.libImage }}"
-      EXPERIMENT_IMAGE_PULL_POLICY: "${{ github.event.inputs.experimentImagePullPolicy }}"
       CHAOS_NAMESPACE: "${{ github.event.inputs.chaosNamespace }}"
       APP_NS: "${{ github.event.inputs.chaosNamespace }}"
       CHAOS_SERVICE_ACCOUNT: "${{ github.event.inputs.chaosServiceAccount }}"
@@ -363,7 +355,6 @@ jobs:
     env:
       GO_EXPERIMENT_IMAGE: "${{ github.event.inputs.goExperimentImage }}"
       LIB_IMAGE: "${{ github.event.inputs.libImage }}"
-      EXPERIMENT_IMAGE_PULL_POLICY: "${{ github.event.inputs.experimentImagePullPolicy }}"
       CHAOS_NAMESPACE: "${{ github.event.inputs.expTunnableNS }}"
       CHAOS_SERVICE_ACCOUNT: "${{ github.event.inputs.chaosServiceAccount }}"
       APP_NS: "${{ github.event.inputs.expTunnableNS }}"
@@ -371,7 +362,6 @@ jobs:
       UPDATE_WEBSITE: "false"
       KUBECONFIG: /etc/rancher/k3s/k3s.yaml
       OPERATOR_IMAGE: "${{ github.event.inputs.operatorImage }}"
-      OPERATOR_NAME: "${{ github.event.inputs.operatorName }}"
       RUNNER_IMAGE: "${{ github.event.inputs.runnerImage }}"
       IMAGE_PULL_POLICY: "${{ github.event.inputs.imagePullPolicy }}"  
       POD_LEVEL: "true"      
@@ -449,7 +439,6 @@ jobs:
     env:
       GO_EXPERIMENT_IMAGE: "${{ github.event.inputs.goExperimentImage }}"
       LIB_IMAGE: "${{ github.event.inputs.libImage }}"
-      EXPERIMENT_IMAGE_PULL_POLICY: "${{ github.event.inputs.experimentImagePullPolicy }}"
       CHAOS_NAMESPACE: "${{ github.event.inputs.expTunnableNS }}"
       CHAOS_SERVICE_ACCOUNT: "${{ github.event.inputs.chaosServiceAccount }}"
       APP_NS: "${{ github.event.inputs.expTunnableNS }}"
@@ -457,7 +446,6 @@ jobs:
       UPDATE_WEBSITE: "false"
       KUBECONFIG: /etc/rancher/k3s/k3s.yaml
       OPERATOR_IMAGE: "${{ github.event.inputs.operatorImage }}"
-      OPERATOR_NAME: "${{ github.event.inputs.operatorName }}"
       RUNNER_IMAGE: "${{ github.event.inputs.runnerImage }}"
       IMAGE_PULL_POLICY: "${{ github.event.inputs.imagePullPolicy }}"
       POD_LEVEL: "true"      
@@ -537,7 +525,6 @@ jobs:
     env:
       GO_EXPERIMENT_IMAGE: "${{ github.event.inputs.goExperimentImage }}"
       LIB_IMAGE: "${{ github.event.inputs.libImage }}"
-      EXPERIMENT_IMAGE_PULL_POLICY: "${{ github.event.inputs.experimentImagePullPolicy }}"
       CHAOS_NAMESPACE: "${{ github.event.inputs.expTunnableNS }}"
       CHAOS_SERVICE_ACCOUNT: "${{ github.event.inputs.chaosServiceAccount }}"
       APP_NS: "${{ github.event.inputs.expTunnableNS }}"
@@ -545,7 +532,6 @@ jobs:
       UPDATE_WEBSITE: "false"
       KUBECONFIG: /etc/rancher/k3s/k3s.yaml
       OPERATOR_IMAGE: "${{ github.event.inputs.operatorImage }}"
-      OPERATOR_NAME: "${{ github.event.inputs.operatorName }}"
       RUNNER_IMAGE: "${{ github.event.inputs.runnerImage }}"
       IMAGE_PULL_POLICY: "${{ github.event.inputs.imagePullPolicy }}" 
       POD_LEVEL: "true"      

--- a/.github/workflows/scheduled-pod-level-pipeline.yml
+++ b/.github/workflows/scheduled-pod-level-pipeline.yml
@@ -24,8 +24,8 @@ jobs:
 
       - uses: actions/checkout@v2
         with:
-          repository: '${{ github.event.inputs.e2eTestRepo }}'
-          ref: '${{ github.event.inputs.e2eTestBranch }}'      
+          repository: 'litmuschaos/litmus-e2e'
+          ref: 'master'      
     
       - name: Installing Prerequisites (K3S Cluster)
         run: |
@@ -102,9 +102,8 @@ jobs:
 
       - uses: actions/checkout@v2
         with:
-          repository: '${{ github.event.inputs.e2eTestRepo }}'
-          ref: '${{ github.event.inputs.e2eTestBranch }}'      
-    
+          repository: 'litmuschaos/litmus-e2e'
+          ref: 'master'      
 
       - name: Installing Prerequisites (K3S Cluster)
         run: |
@@ -189,8 +188,8 @@ jobs:
 
       - uses: actions/checkout@v2
         with:
-          repository: '${{ github.event.inputs.e2eTestRepo }}'
-          ref: '${{ github.event.inputs.e2eTestBranch }}'      
+          repository: 'litmuschaos/litmus-e2e'
+          ref: 'master'      
     
       - name: Installing Prerequisites (K3S Cluster)
         run: |
@@ -255,8 +254,8 @@ jobs:
 
       - uses: actions/checkout@v2
         with:
-          repository: '${{ github.event.inputs.e2eTestRepo }}'
-          ref: '${{ github.event.inputs.e2eTestBranch }}'      
+          repository: 'litmuschaos/litmus-e2e'
+          ref: 'master'      
     
       - name: Installing Prerequisites (K3S Cluster)
         run: |
@@ -323,8 +322,8 @@ jobs:
 
       - uses: actions/checkout@v2
         with:
-          repository: '${{ github.event.inputs.e2eTestRepo }}'
-          ref: '${{ github.event.inputs.e2eTestBranch }}'      
+          repository: 'litmuschaos/litmus-e2e'
+          ref: 'master'      
 
       - name: Installing Prerequisites (K3S Cluster)
         run: |
@@ -400,8 +399,8 @@ jobs:
 
       - uses: actions/checkout@v2
         with:
-          repository: '${{ github.event.inputs.e2eTestRepo }}'
-          ref: '${{ github.event.inputs.e2eTestBranch }}'      
+          repository: 'litmuschaos/litmus-e2e'
+          ref: 'master'      
 
       - name: Installing Prerequisites (K3S Cluster)
         run: |
@@ -479,8 +478,8 @@ jobs:
 
       - uses: actions/checkout@v2
         with:
-          repository: '${{ github.event.inputs.e2eTestRepo }}'
-          ref: '${{ github.event.inputs.e2eTestBranch }}'      
+          repository: 'litmuschaos/litmus-e2e'
+          ref: 'master'      
 
       - name: Installing Prerequisites (K3S Cluster)
         run: |

--- a/.github/workflows/scheduled-pod-level-pipeline.yml
+++ b/.github/workflows/scheduled-pod-level-pipeline.yml
@@ -4,88 +4,44 @@ on:
   schedule:
     - cron: "30 20 * * *" # Daily 02:30 AM in midnight
 
-defaults:
-  run:
-    working-directory: /go/src
-
 jobs:
-  ### Setup Litmus
 
-  Setup_Litmus_Infra:
-    container:
-      image: "litmuschaos/litmus-e2e:ci"
-      volumes:
-        - /home/ubuntu/.kube:/root/.kube
-        - /home/ubuntu/.aws:/root/.aws
-        - /etc/kubernetes:/etc/kubernetes
-      env:
-        KUBECONFIG: /root/.kube/config
-
-    runs-on: [self-hosted, pod-level]
-
+  Network_Chaos_Test:
+    if: always()
+    runs-on: ubuntu-latest
+    env:
+      CHAOS_NAMESPACE: "litmus"
+      APP_NS: "litmus"
+      UPDATE_WEBSITE: "true"
+      KUBECONFIG: /etc/rancher/k3s/k3s.yaml   
+      POD_LEVEL: "true"      
+    
     steps:
+    
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.16'
+
+      - uses: actions/checkout@v2
+        with:
+          repository: '${{ github.event.inputs.e2eTestRepo }}'
+          ref: '${{ github.event.inputs.e2eTestBranch }}'      
+    
+      - name: Installing Prerequisites (K3S Cluster)
+        run: |
+          curl -sfL https://get.k3s.io | sh -s - --docker --write-kubeconfig-mode 664
+          kubectl wait node --all --for condition=ready --timeout=90s
+          kubectl get nodes
+          
       - name: Litmus Infra Setup In Cluster-1
+        if: ${{ always() }}      
         run: |
           make build-litmus
 
-  ### Setup App
-
-  Setup_App_Deployment:
-    needs: Setup_Litmus_Infra
-    container:
-      image: "litmuschaos/litmus-e2e:ci"
-      volumes:
-        - /home/ubuntu/.kube:/root/.kube
-        - /home/ubuntu/.aws:/root/.aws
-        - /etc/kubernetes:/etc/kubernetes
-      env:
-        KUBECONFIG: /root/.kube/config
-
-    runs-on: [self-hosted, pod-level]
-    steps:
       - name: Deploy App In Cluster-1
+        if: ${{ always() }}      
         run: make app-deploy
-
-    ## TODO: Make use of app liveness check and aux app
-    # - name: Liveness In Cluster-1
-    #   if: ${{ always() }}
-    #   run: make liveness
-
-    # - name: Auxiliary App In Cluster-1
-    #   if: ${{ always() }}
-    #   run: make auxiliary-app
-
-  ### Runing Pod Level Tests
-
-  Pod_Level_Test:
-    needs: Setup_App_Deployment
-    if: always()
-    container:
-      image: "litmuschaos/litmus-e2e:ci"
-      volumes:
-        - /home/ubuntu/.kube:/root/.kube
-        - /home/ubuntu/.aws:/root/.aws
-        - /etc/kubernetes:/etc/kubernetes
-      env:
-        KUBECONFIG: /root/.kube/config
-
-    runs-on: [self-hosted, pod-level]
-    steps:
-      - name: TCID-EC2-GENERIC-APP-POD-DELETE
-        run: make pod-delete
-
-      - name: TCID-EC2-GENERIC-APP-CONTAINER-KILL
-        if: ${{ always() }}
-        run: make container-kill
-
-      - name: TCID-EC2-GENERIC-APP-POD-CPU-HOG
-        if: ${{ always() }}
-        run: make pod-cpu-hog
-
-      - name: TCID-EC2-GENERIC-APP-POD-MEMORY-HOG
-        if: ${{ always() }}
-        run: make pod-memory-hog
-
+    
       - name: TCID-EC2-GENERIC-APP-POD-NETWORK-CORRUPTION
         if: ${{ always() }}
         run: make pod-network-corruption
@@ -101,6 +57,85 @@ jobs:
       - name: TCID-EC2-GENERIC-APP-POD-NETWORK-DUPLICATION
         if: ${{ always() }}
         run: make pod-network-duplication
+        
+      - name: "[Debug]: check chaos resources"
+        if: ${{ failure() }}
+        continue-on-error: true
+        run: |
+          bash <(curl -s https://raw.githubusercontent.com/litmuschaos/litmus-e2e/master/build/debug.sh)
+          
+      - name: "[Debug]: check operator logs"
+        if: ${{ failure() }}
+        continue-on-error: true
+        run: |      
+          operator_name=$(kubectl get pods -n litmus -l app.kubernetes.io/component=operator --no-headers | awk '{print$1}')
+          kubectl logs $operator_name -n litmus > logs.txt
+          cat logs.txt        
+        
+      - name: Application Cleanup
+        if: ${{ always() }}      
+        run: make app-cleanup
+
+      - name: Litmus Cleanup
+        if: ${{ always() }}      
+        run: make litmus-cleanup 
+        
+      - name: Deleting K3S cluster
+        if: always()
+        run: /usr/local/bin/k3s-uninstall.sh
+        
+  Stress_Chaos_Test:
+    if: always()
+    runs-on: ubuntu-latest
+    env:
+      CHAOS_NAMESPACE: "litmus"
+      APP_NS: "litmus"
+      UPDATE_WEBSITE: "true"
+      KUBECONFIG: /etc/rancher/k3s/k3s.yaml   
+      POD_LEVEL: "true"     
+    
+    steps:
+    
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.16'
+
+      - uses: actions/checkout@v2
+        with:
+          repository: '${{ github.event.inputs.e2eTestRepo }}'
+          ref: '${{ github.event.inputs.e2eTestBranch }}'      
+    
+
+      - name: Installing Prerequisites (K3S Cluster)
+        run: |
+          curl -sfL https://get.k3s.io | sh -s - --docker --write-kubeconfig-mode 664
+          kubectl wait node --all --for condition=ready --timeout=90s
+          kubectl get nodes
+          
+      - name: Litmus Infra Setup In Cluster-1
+        if: ${{ always() }}      
+        run: |
+          make build-litmus
+
+      - name: Deploy App In Cluster-1
+        if: ${{ always() }}      
+        run: make app-deploy
+    
+      - name: TCID-EC2-GENERIC-APP-POD-CPU-HOG
+        if: ${{ always() }}
+        run: make pod-cpu-hog
+
+      - name: TCID-EC2-GENERIC-APP-POD-MEMORY-HOG
+        if: ${{ always() }}
+        run: make pod-memory-hog
+
+      - name: TCID-EC2-GENERIC-APP-POD-CPU-HOG-EXEC
+        if: ${{ always() }}
+        run: make pod-cpu-hog-exec
+
+      - name: TCID-EC2-GENERIC-APP-POD-MEMORY-HOG-EXEC
+        if: ${{ always() }}
+        run: make pod-memory-hog-exec        
 
       - name: TCID-EC2-GENERIC-APP-POD-IO-STRESS
         if: ${{ always() }}
@@ -109,87 +144,406 @@ jobs:
       - name: TCID-EC2-GENERIC-APP-DISK-FILL
         if: ${{ always() }}
         run: make disk-fill
+        
+      - name: "[Debug]: check chaos resources"
+        if: ${{ failure() }}
+        continue-on-error: true
+        run: |
+          bash <(curl -s https://raw.githubusercontent.com/litmuschaos/litmus-e2e/master/build/debug.sh)
+          
+      - name: "[Debug]: check operator logs"
+        if: ${{ failure() }}
+        continue-on-error: true
+        run: |      
+          operator_name=$(kubectl get pods -n litmus -l app.kubernetes.io/component=operator --no-headers | awk '{print$1}')
+          kubectl logs $operator_name -n litmus > logs.txt
+          cat logs.txt        
+        
+      - name: Application Cleanup
+        if: ${{ always() }}      
+        run: make app-cleanup
+
+      - name: Litmus Cleanup
+        if: ${{ always() }}      
+        run: make litmus-cleanup         
+        
+      - name: Deleting K3S cluster
+        if: always()
+        run: /usr/local/bin/k3s-uninstall.sh   
+
+  Container_Kill_Test:
+    if: always()
+    runs-on: ubuntu-latest
+    env:
+      CHAOS_NAMESPACE: "litmus"
+      APP_NS: "litmus"
+      UPDATE_WEBSITE: "true"
+      KUBECONFIG: /etc/rancher/k3s/k3s.yaml   
+      POD_LEVEL: "true"     
+    
+    steps:
+    
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.16'
+
+      - uses: actions/checkout@v2
+        with:
+          repository: '${{ github.event.inputs.e2eTestRepo }}'
+          ref: '${{ github.event.inputs.e2eTestBranch }}'      
+    
+      - name: Installing Prerequisites (K3S Cluster)
+        run: |
+          curl -sfL https://get.k3s.io | sh -s - --docker --write-kubeconfig-mode 664
+          kubectl wait node --all --for condition=ready --timeout=90s
+          kubectl get nodes
+          
+      - name: Litmus Infra Setup In Cluster-1
+        if: ${{ always() }}      
+        run: |
+          make build-litmus
+
+      - name: Deploy App In Cluster-1
+        if: ${{ always() }}      
+        run: make app-deploy
+    
+      - name: TCID-EC2-GENERIC-APP-CONTAINER-KILL
+        if: ${{ always() }}
+        run: make container-kill
+        
+      - name: "[Debug]: check chaos resources"
+        if: ${{ failure() }}
+        continue-on-error: true
+        run: |
+          bash <(curl -s https://raw.githubusercontent.com/litmuschaos/litmus-e2e/master/build/debug.sh)
+          
+      - name: "[Debug]: check operator logs"
+        if: ${{ failure() }}
+        continue-on-error: true
+        run: |      
+          operator_name=$(kubectl get pods -n litmus -l app.kubernetes.io/component=operator --no-headers | awk '{print$1}')
+          kubectl logs $operator_name -n litmus > logs.txt
+          cat logs.txt        
+        
+      - name: Application Cleanup
+        if: ${{ always() }}      
+        run: make app-cleanup
+
+      - name: Litmus Cleanup
+        if: ${{ always() }}      
+        run: make litmus-cleanup      
+        
+      - name: Deleting K3S cluster
+        if: always()
+        run: /usr/local/bin/k3s-uninstall.sh        
+
+  Pod_Delete_Test:
+    if: always()
+    runs-on: ubuntu-latest
+    env:
+      CHAOS_NAMESPACE: "litmus"
+      APP_NS: "litmus"
+      UPDATE_WEBSITE: "true"
+      KUBECONFIG: /etc/rancher/k3s/k3s.yaml   
+      POD_LEVEL: "true"       
+    
+    steps:
+    
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.16'
+
+      - uses: actions/checkout@v2
+        with:
+          repository: '${{ github.event.inputs.e2eTestRepo }}'
+          ref: '${{ github.event.inputs.e2eTestBranch }}'      
+    
+      - name: Installing Prerequisites (K3S Cluster)
+        run: |
+          curl -sfL https://get.k3s.io | sh -s - --docker --write-kubeconfig-mode 664
+          kubectl wait node --all --for condition=ready --timeout=90s
+          kubectl get nodes
+          
+      - name: Litmus Infra Setup In Cluster-1
+        if: ${{ always() }}      
+        run: |
+          make build-litmus
+
+      - name: Deploy App In Cluster-1
+        if: ${{ always() }}      
+        run: make app-deploy
+    
+      - name: TCID-EC2-GENERIC-APP-POD-DELETE
+        if: ${{ always() }}      
+        run: make pod-delete
+        
+      - name: "[Debug]: check chaos resources"
+        if: ${{ failure() }}
+        continue-on-error: true
+        run: |
+          bash <(curl -s https://raw.githubusercontent.com/litmuschaos/litmus-e2e/master/build/debug.sh)
+          
+      - name: "[Debug]: check operator logs"
+        if: ${{ failure() }}
+        continue-on-error: true
+        run: |      
+          operator_name=$(kubectl get pods -n litmus -l app.kubernetes.io/component=operator --no-headers | awk '{print$1}')
+          kubectl logs $operator_name -n litmus > logs.txt
+          cat logs.txt        
+        
+      - name: Application Cleanup
+        if: ${{ always() }}      
+        run: make app-cleanup
+
+      - name: Litmus Cleanup
+        if: ${{ always() }}      
+        run: make litmus-cleanup      
+        
+      - name: Deleting K3S cluster
+        if: always()
+        run: /usr/local/bin/k3s-uninstall.sh        
+
 
   ### Runing Experiment Tunables
-
-  Experiment_Tunables:
-    needs: Pod_Level_Test
+  PAP_100_Mode_Parallel:
     if: always()
-    container:
-      image: "litmuschaos/litmus-e2e:ci"
-      volumes:
-        - /home/ubuntu/.kube:/root/.kube
-        - /home/ubuntu/.aws:/root/.aws
-        - /etc/kubernetes:/etc/kubernetes
-      env:
-        KUBECONFIG: /root/.kube/config
-
-    runs-on: [self-hosted, pod-level]
+    runs-on: ubuntu-latest
+    env:
+      CHAOS_NAMESPACE: "litmus"
+      APP_NS: "litmus"
+      UPDATE_WEBSITE: "true"
+      KUBECONFIG: /etc/rancher/k3s/k3s.yaml   
+      POD_LEVEL: "true"        
+    
     steps:
+
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.16'
+
+      - uses: actions/checkout@v2
+        with:
+          repository: '${{ github.event.inputs.e2eTestRepo }}'
+          ref: '${{ github.event.inputs.e2eTestBranch }}'      
+
+      - name: Installing Prerequisites (K3S Cluster)
+        run: |
+          curl -sfL https://get.k3s.io | sh -s - --docker --write-kubeconfig-mode 664
+          kubectl wait node --all --for condition=ready --timeout=90s
+          kubectl get nodes
+          
+      - name: Litmus Infra Setup In Cluster-1
+        run: |
+          make build-litmus
+
+      - name: Deploy App In Cluster-1
+        run: make app-deploy
+        
+      - name: Create Namespace and deploy Application
+        run: |
+          kubectl create ns ${CHAOS_NAMESPACE}
+          kubectl create deploy nginx --image=nginx:alpine -n ${CHAOS_NAMESPACE}
+          kubectl wait --for=condition=Ready pods --all --namespace ${CHAOS_NAMESPACE} --timeout=90s
+          kubectl annotate deploy/nginx litmuschaos.io/chaos="true" -n ${CHAOS_NAMESPACE} --overwrite
+
       - name: TCID-EC2-GENERIC-APP-POD-AFFECTED-PERCENTAGE-TON-PARALLEL
         run: make pod-affected-perc-ton-parallel
 
+      - name: Experiment Tunables Cleanup
+        if: ${{ always() }}
+        run: |
+          kubectl delete chaosengines --all -n ${CHAOS_NAMESPACE}
+          kubectl delete ns ${CHAOS_NAMESPACE}
+          
+      - name: "[Debug]: check chaos resources"
+        if: ${{ failure() }}
+        continue-on-error: true
+        run: |
+          bash <(curl -s https://raw.githubusercontent.com/litmuschaos/litmus-e2e/master/build/debug.sh)
+          
+      - name: "[Debug]: check operator logs"
+        if: ${{ failure() }}
+        continue-on-error: true
+        run: |      
+          operator_name=$(kubectl get pods -n litmus -l app.kubernetes.io/component=operator --no-headers | awk '{print$1}')
+          kubectl logs $operator_name -n litmus > logs.txt
+          cat logs.txt          
+          
+      - name: Application Cleanup
+        if: ${{ always() }}      
+        run: make app-cleanup
+
+      - name: Litmus Cleanup
+        if: ${{ always() }}      
+        run: make litmus-cleanup    
+        
+      - name: Deleting K3S cluster
+        if: always()
+        run: /usr/local/bin/k3s-uninstall.sh        
+
+  ### Runing Experiment Tunables
+  PAP_100_Mode_Serial:
+    if: always()
+    runs-on: ubuntu-latest
+    env:
+      CHAOS_NAMESPACE: "litmus"
+      APP_NS: "litmus"
+      UPDATE_WEBSITE: "true"
+      KUBECONFIG: /etc/rancher/k3s/k3s.yaml   
+      POD_LEVEL: "true"      
+    
+    steps:
+
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.16'
+
+      - uses: actions/checkout@v2
+        with:
+          repository: '${{ github.event.inputs.e2eTestRepo }}'
+          ref: '${{ github.event.inputs.e2eTestBranch }}'      
+
+      - name: Installing Prerequisites (K3S Cluster)
+        run: |
+          curl -sfL https://get.k3s.io | sh -s - --docker --write-kubeconfig-mode 664
+          kubectl wait node --all --for condition=ready --timeout=90s
+          kubectl get nodes
+          
+      - name: Litmus Infra Setup In Cluster-1
+        run: |
+          make build-litmus
+
+      - name: Deploy App In Cluster-1
+        run: make app-deploy
+        
+      - name: Create Namespace and deploy Application
+        run: |
+          kubectl create ns ${CHAOS_NAMESPACE}
+          kubectl create deploy nginx --image=nginx:alpine -n ${CHAOS_NAMESPACE}
+          kubectl wait --for=condition=Ready pods --all --namespace ${CHAOS_NAMESPACE} --timeout=90s
+          kubectl annotate deploy/nginx litmuschaos.io/chaos="true" -n ${CHAOS_NAMESPACE} --overwrite
+          
       - name: TCID-EC2-GENERIC-APP-POD-AFFECTED-PERCENTAGE-TON-SERIES
         if: ${{ always() }}
         run: make pod-affected-perc-ton-series
 
+      - name: Experiment Tunables Cleanup
+        if: ${{ always() }}
+        run: |
+          kubectl delete chaosengines --all -n ${CHAOS_NAMESPACE}
+          kubectl delete ns ${CHAOS_NAMESPACE}
+          
+      - name: "[Debug]: check chaos resources"
+        if: ${{ failure() }}
+        continue-on-error: true
+        run: |
+          bash <(curl -s https://raw.githubusercontent.com/litmuschaos/litmus-e2e/master/build/debug.sh)
+          
+      - name: "[Debug]: check operator logs"
+        if: ${{ failure() }}
+        continue-on-error: true
+        run: |      
+          operator_name=$(kubectl get pods -n litmus -l app.kubernetes.io/component=operator --no-headers | awk '{print$1}')
+          kubectl logs $operator_name -n litmus > logs.txt
+          cat logs.txt          
+          
+      - name: Application Cleanup
+        if: ${{ always() }}      
+        run: make app-cleanup
+
+      - name: Litmus Cleanup
+        if: ${{ always() }}      
+        run: make litmus-cleanup       
+        
+      - name: Deleting K3S cluster
+        if: always()
+        run: /usr/local/bin/k3s-uninstall.sh        
+
+
+  ### Runing Experiment Tunables
+  Multiple_App_Deploy:
+    if: always()
+    runs-on: ubuntu-latest
+    env:
+      CHAOS_NAMESPACE: "litmus"
+      APP_NS: "litmus"
+      UPDATE_WEBSITE: "true"
+      KUBECONFIG: /etc/rancher/k3s/k3s.yaml   
+      POD_LEVEL: "true"      
+    
+    steps:
+
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.16'
+
+      - uses: actions/checkout@v2
+        with:
+          repository: '${{ github.event.inputs.e2eTestRepo }}'
+          ref: '${{ github.event.inputs.e2eTestBranch }}'      
+
+      - name: Installing Prerequisites (K3S Cluster)
+        run: |
+          curl -sfL https://get.k3s.io | sh -s - --docker --write-kubeconfig-mode 664
+          kubectl wait node --all --for condition=ready --timeout=90s
+          kubectl get nodes
+          
+      - name: Litmus Infra Setup In Cluster-1
+        run: |
+          make build-litmus
+
+      - name: Deploy App In Cluster-1
+        run: make app-deploy
+        
+      - name: Create Namespace and deploy Application
+        run: |
+          kubectl create ns ${CHAOS_NAMESPACE}
+          kubectl create deploy nginx --image=nginx:alpine -n ${CHAOS_NAMESPACE}
+          kubectl wait --for=condition=Ready pods --all --namespace ${CHAOS_NAMESPACE} --timeout=90s
+          kubectl annotate deploy/nginx litmuschaos.io/chaos="true" -n ${CHAOS_NAMESPACE} --overwrite
+
       - name: TCID-EC2-GENERIC-APP-MULTIPLE-APP-DEPLOY
         if: ${{ always() }}
         run: make multiple-app-deploy
+        
+      - name: "[Debug]: check chaos resources"
+        if: ${{ failure() }}
+        continue-on-error: true
+        run: |
+          bash <(curl -s https://raw.githubusercontent.com/litmuschaos/litmus-e2e/master/build/debug.sh)
+          
+      - name: "[Debug]: check operator logs"
+        if: ${{ failure() }}
+        continue-on-error: true
+        run: |      
+          operator_name=$(kubectl get pods -n litmus -l app.kubernetes.io/component=operator --no-headers | awk '{print$1}')
+          kubectl logs $operator_name -n litmus > logs.txt
+          cat logs.txt        
 
-  ### App Cleanup
+      - name: Experiment Tunables Cleanup
+        if: ${{ always() }}
+        run: |
+          kubectl delete chaosengines --all -n ${CHAOS_NAMESPACE}
+          kubectl delete ns ${CHAOS_NAMESPACE}
 
-  App_Cleanup:
-    needs: Experiment_Tunables
-    if: always()
-    container:
-      image: "litmuschaos/litmus-e2e:ci"
-      volumes:
-        - /home/ubuntu/.kube:/root/.kube
-        - /home/ubuntu/.aws:/root/.aws
-        - /etc/kubernetes:/etc/kubernetes
-      env:
-        KUBECONFIG: /root/.kube/config
-
-    runs-on: [self-hosted, pod-level]
-    steps:
-      - name: Application Cleanup
-        run: make app-cleanup
-
-  ### Litmus Cleanup
-
-  Litmus_Cleanup:
-    needs: App_Cleanup
-    if: always()
-    container:
-      image: "litmuschaos/litmus-e2e:ci"
-      volumes:
-        - /home/ubuntu/.kube:/root/.kube
-        - /home/ubuntu/.aws:/root/.aws
-        - /etc/kubernetes:/etc/kubernetes
-      env:
-        KUBECONFIG: /root/.kube/config
-        POD_LEVEL: "true"
-
-    runs-on: [self-hosted, pod-level]
-    steps:
       - name: Litmus Cleanup
-        run: make litmus-cleanup
+        if: ${{ always() }}      
+        run: make litmus-cleanup 
+        
+      - name: Deleting K3S cluster
+        if: always()
+        run: /usr/local/bin/k3s-uninstall.sh        
 
   ### Website Update
-
   Pipeline_Update:
-    needs: Litmus_Cleanup
+    needs: [ Network_Chaos_Test,Stress_Chaos_Test,Container_Kill_Test,Pod_Delete_Test,PAP_100_Mode_Parallel,PAP_100_Mode_Serial,Multiple_App_Deploy ]
     if: always()
     env:
       CI_PIPELINE_ID: ${{ github.run_id }}
       POD_LEVEL: "true"
       UPDATE_WEBSITE: "true"
       GITHUB_TOKEN: ${{ secrets.ADMIN_TOKEN }}
-    container:
-      image: "litmuschaos/litmus-e2e:ci"
-
-    runs-on: [self-hosted, pod-level]
+    runs-on: ubuntu-latest
     steps:
       - name: Pipeline Update
         run: make pipeline-status-update

--- a/build/debug.sh
+++ b/build/debug.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+echo "#############################################################"
+echo "############ Getting Node Status ################"
+echo "#############################################################"
+echo 
+echo "kubectl get nodes"
+kubectl get nodes || true
+
+echo "#############################################################"
+echo "############ Getting pods in Chaos Namespace ################"
+echo "#############################################################"
+echo 
+echo "kubectl get pods -n ${CHAOS_NAMESPACE}"
+kubectl get pods -n ${CHAOS_NAMESPACE} || true
+echo
+echo "###################################################################"
+echo "############ Getting pods in Application Namespace ################"
+echo "###################################################################"
+echo
+echo "kubectl get pods -n ${APP_NS}"
+kubectl get pods -n ${APP_NS} || true
+echo
+echo "################################################################"
+echo "############ Getting Chaos Resource Information ################"
+echo "################################################################"
+echo
+echo "kubectl get chaosengine,chaosexperiment,chaosresult -n ${CHAOS_NAMESPACE}"
+kubectl get chaosengine,chaosexperiment,chaosresult -n ${CHAOS_NAMESPACE} || true
+echo
+echo "################################################################"
+echo "############ Getting Service Account Information ################"
+echo "################################################################"
+echo
+echo "kubectl get sa -n ${CHAOS_NAMESPACE}"
+kubectl get sa -n ${CHAOS_NAMESPACE} || true
+echo
+echo "###################################################"
+echo "############ Describe ChaosEngine  ################"
+echo "###################################################"
+echo
+echo "kubectl describe chaosengine -n ${CHAOS_NAMESPACE}"
+kubectl describe chaosengine -n ${CHAOS_NAMESPACE} || true
+echo
+echo "###################################################"
+echo "############ Describe ChaosResult  ################"
+echo "###################################################"
+echo
+echo "kubectl describe chaosresult -n ${CHAOS_NAMESPACE}"
+kubectl describe chaosresult -n ${CHAOS_NAMESPACE} || true
+echo


### PR DESCRIPTION
Signed-off-by: udit <udit@chaosnative.com>

## Details 

- Shift pod level pipeline clusters from kubeadm on ec2 to a transient kind/k3s cluster
- We can use a shared runner also in place of the self-hosted runner.
- The pipeline has a well-defined debug step to catch any test failure.

#### Tested Run - [Click Here](https://github.com/uditgaurav/test-litmus-e2e/actions/runs/1146724778)
#### Issue:
- https://github.com/litmuschaos/litmus-e2e/issues/299 


#### Screenshot

![image](https://user-images.githubusercontent.com/35391335/130217428-d9aa6753-5159-40aa-a102-032521880d5d.png)
