### PR TITLE
fix(pipeline): follow a single convention for pipeline naming

### DIFF
--- a/.github/workflows/portal-pipeline.yml
+++ b/.github/workflows/portal-pipeline.yml
@@ -1,4 +1,4 @@
-name: Portal-E2E K3S Pipeline
+name: Portal-E2E-K3S-Pipeline
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/scheduled-Portal-pipeline.yml
+++ b/.github/workflows/scheduled-Portal-pipeline.yml
@@ -1,4 +1,4 @@
-name: Scheuled Portal-E2E Pipeline
+name: Scheduled Portal-E2E Pipeline
 on:
   schedule:
     - cron: "30 22 * * *" # Daily 04:30 AM in midnight

--- a/.github/workflows/scheduled-Portal-pipeline.yml
+++ b/.github/workflows/scheduled-Portal-pipeline.yml
@@ -1,4 +1,4 @@
-name: Scheduled Portal-E2E Pipeline
+name: Scheduled-Portal-E2E-Pipeline
 on:
   schedule:
     - cron: "30 22 * * *" # Daily 04:30 AM in midnight


### PR DESCRIPTION
- Corrected name from `Scheuled` to `Scheduled`
- Fixed pipeline name to follow a single convention (`-` as a separator). It will be helpful to dynamically filter scheduled pipelines from all pipelines in the e2e dashboard.
