### PR TITLE
GCP Pipeline Fixes

### DIFF
--- a/.github/workflows/gcp-experiment-pipeline.yml
+++ b/.github/workflows/gcp-experiment-pipeline.yml
@@ -176,8 +176,8 @@ jobs:
           gcloud compute instances create litmus-e2e-vm-${{ github.run_number }} \
           --machine-type=f1-micro \
           --zone=us-central1-a \
-          --create-disk name=litmus-e2e-first-disk-${{ github.run_number }},size=1GB,device-name=litmus-e2e-first-disk-${{ github.run_number }} \
-          --create-disk name=litmus-e2e-second-disk-${{ github.run_number }},size=1GB,device-name=litmus-e2e-second-disk-${{ github.run_number }}
+          --create-disk name=litmus-e2e-first-disk-${{ github.run_number }},size=1GB \
+          --create-disk name=litmus-e2e-second-disk-${{ github.run_number }},size=1GB
 
       - name: Litmus Infra Setup
         if: always()
@@ -192,7 +192,6 @@ jobs:
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
           DISK_VOLUME_NAMES: "litmus-e2e-first-disk-${{ github.run_number }},litmus-e2e-second-disk-${{ github.run_number }}"
           DISK_ZONES: "us-central1-a,us-central1-a"
-          DEVICE_NAMES: "litmus-e2e-first-disk-${{ github.run_number }},litmus-e2e-second-disk-${{ github.run_number }}"
           EXPERIMENT_IMAGE: "${{ github.event.inputs.experimentImage }}"
           EXPERIMENT_IMAGE_PULL_POLICY: "${{ github.event.inputs.experimentImagePullPolicy }}"
           CHAOS_NAMESPACE: "${{ github.event.inputs.chaosNamespace }}"

--- a/.github/workflows/gcp-experiment-pipeline.yml
+++ b/.github/workflows/gcp-experiment-pipeline.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           gcloud compute instances create litmus-e2e-first-vm-${{ github.run_number }} litmus-e2e-second-vm-${{ github.run_number }} \
           --machine-type=f1-micro \
-          --zone=us-central1-a
+          --zone=us-east1-b
 
       - name: Litmus Infra Setup
         if: always()
@@ -84,7 +84,7 @@ jobs:
         env:
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
           VM_INSTANCE_NAMES: "litmus-e2e-first-vm-${{ github.run_number }},litmus-e2e-second-vm-${{ github.run_number }}"
-          INSTANCE_ZONES: "us-central1-a,us-central1-a"
+          INSTANCE_ZONES: "us-east1-b,us-east1-b"
           EXPERIMENT_IMAGE: "${{ github.event.inputs.experimentImage }}"
           EXPERIMENT_IMAGE_PULL_POLICY: "${{ github.event.inputs.experimentImagePullPolicy }}"
           CHAOS_NAMESPACE: "${{ github.event.inputs.chaosNamespace }}"
@@ -94,7 +94,7 @@ jobs:
         if: always()
         run: |
           gcloud compute instances delete litmus-e2e-first-vm-${{ github.run_number }} litmus-e2e-second-vm-${{ github.run_number }} \
-          --zone=us-central1-a \
+          --zone=us-east1-b \
           --quiet
 
       - name: "[Debug]: check chaos resources"
@@ -175,7 +175,7 @@ jobs:
         run: |
           gcloud compute instances create litmus-e2e-vm-${{ github.run_number }} \
           --machine-type=f1-micro \
-          --zone=us-central1-a \
+          --zone=us-east1-b \
           --create-disk name=litmus-e2e-first-disk-${{ github.run_number }},size=1GB \
           --create-disk name=litmus-e2e-second-disk-${{ github.run_number }},size=1GB
 
@@ -191,7 +191,7 @@ jobs:
         env:
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
           DISK_VOLUME_NAMES: "litmus-e2e-first-disk-${{ github.run_number }},litmus-e2e-second-disk-${{ github.run_number }}"
-          DISK_ZONES: "us-central1-a,us-central1-a"
+          DISK_ZONES: "us-east1-b,us-east1-b"
           EXPERIMENT_IMAGE: "${{ github.event.inputs.experimentImage }}"
           EXPERIMENT_IMAGE_PULL_POLICY: "${{ github.event.inputs.experimentImagePullPolicy }}"
           CHAOS_NAMESPACE: "${{ github.event.inputs.chaosNamespace }}"
@@ -201,7 +201,7 @@ jobs:
         if: always()
         run: |
           gcloud compute instances delete litmus-e2e-vm-${{ github.run_number }} \
-          --zone=us-central1-a \
+          --zone=us-east1-b \
           --delete-disks=all \
           --quiet
 

--- a/.github/workflows/nightly-gcp-experiment-pipeline.yml
+++ b/.github/workflows/nightly-gcp-experiment-pipeline.yml
@@ -62,7 +62,7 @@ jobs:
         run: |
           gcloud compute instances create litmus-e2e-first-vm-${{ github.run_number }} litmus-e2e-second-vm-${{ github.run_number }} \
           --machine-type=f1-micro \
-          --zone=us-central1-a
+          --zone=us-east1-b
 
       - name: Litmus Infra Setup
         if: always()
@@ -73,14 +73,14 @@ jobs:
         env:
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
           VM_INSTANCE_NAMES: "litmus-e2e-first-vm-${{ github.run_number }},litmus-e2e-second-vm-${{ github.run_number }}"
-          INSTANCE_ZONES: "us-central1-a,us-central1-a"
+          INSTANCE_ZONES: "us-east1-b,us-east1-b"
         run: make gcp-vm-instance-stop
 
       - name: Delete target GCP VM Instances
         if: always()
         run: |
           gcloud compute instances delete litmus-e2e-first-vm-${{ github.run_number }} litmus-e2e-second-vm-${{ github.run_number }} \
-          --zone=us-central1-a \
+          --zone=us-east1-b \
           --quiet
 
       - name: "[Debug]: check chaos resources"
@@ -161,7 +161,7 @@ jobs:
         run: |
           gcloud compute instances create litmus-e2e-vm-${{ github.run_number }} \
           --machine-type=f1-micro \
-          --zone=us-central1-a \
+          --zone=us-east1-b \
           --create-disk name=litmus-e2e-first-disk-${{ github.run_number }},size=1GB \
           --create-disk name=litmus-e2e-second-disk-${{ github.run_number }},size=1GB
 
@@ -174,14 +174,14 @@ jobs:
         env:
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
           DISK_VOLUME_NAMES: "litmus-e2e-first-disk-${{ github.run_number }},litmus-e2e-second-disk-${{ github.run_number }}"
-          DISK_ZONES: "us-central1-a,us-central1-a"
+          DISK_ZONES: "us-east1-b,us-east1-b"
         run: make gcp-vm-disk-loss
 
       - name: Delete the VM Instance and target Disk Volumes
         if: always()
         run: |
           gcloud compute instances delete litmus-e2e-vm-${{ github.run_number }} \
-          --zone=us-central1-a \
+          --zone=us-east1-b \
           --delete-disks=all \
           --quiet
 

--- a/.github/workflows/nightly-gcp-experiment-pipeline.yml
+++ b/.github/workflows/nightly-gcp-experiment-pipeline.yml
@@ -162,8 +162,8 @@ jobs:
           gcloud compute instances create litmus-e2e-vm-${{ github.run_number }} \
           --machine-type=f1-micro \
           --zone=us-central1-a \
-          --create-disk name=litmus-e2e-first-disk-${{ github.run_number }},size=1GB,device-name=litmus-e2e-first-disk-${{ github.run_number }} \
-          --create-disk name=litmus-e2e-second-disk-${{ github.run_number }},size=1GB,device-name=litmus-e2e-second-disk-${{ github.run_number }}
+          --create-disk name=litmus-e2e-first-disk-${{ github.run_number }},size=1GB \
+          --create-disk name=litmus-e2e-second-disk-${{ github.run_number }},size=1GB
 
       - name: Litmus Infra Setup
         if: always()
@@ -175,7 +175,6 @@ jobs:
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
           DISK_VOLUME_NAMES: "litmus-e2e-first-disk-${{ github.run_number }},litmus-e2e-second-disk-${{ github.run_number }}"
           DISK_ZONES: "us-central1-a,us-central1-a"
-          DEVICE_NAMES: "litmus-e2e-first-disk-${{ github.run_number }},litmus-e2e-second-disk-${{ github.run_number }}"
         run: make gcp-vm-disk-loss
 
       - name: Delete the VM Instance and target Disk Volumes

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -38,7 +38,6 @@ func GetENV(testDetails *types.TestDetails, expName, engineName string) {
 	testDetails.InstanceZones = Getenv("INSTANCE_ZONES", "")
 	testDetails.DiskVolumeNames = Getenv("DISK_VOLUME_NAMES", "")
 	testDetails.DiskZones = Getenv("DISK_ZONES", "")
-	testDetails.DeviceNames = Getenv("DEVICE_NAMES", "")
 	testDetails.VMIds = Getenv("APP_VM_MOIDS", "")
 	testDetails.Region = Getenv("REGION", "us-west-1")
 	testDetails.UpdateWebsite = Getenv("UPDATE_WEBSITE", "false")

--- a/pkg/install.go
+++ b/pkg/install.go
@@ -334,8 +334,7 @@ func setEngineVar(chaosEngine *v1alpha1.ChaosEngine, testsDetails *types.TestDet
 	case "gcp-vm-disk-loss":
 		envDetails.SetEnv("GCP_PROJECT_ID", testsDetails.GCPProjectID).
 			SetEnv("DISK_VOLUME_NAMES", testsDetails.DiskVolumeNames).
-			SetEnv("DISK_ZONES", testsDetails.DiskZones).
-			SetEnv("DEVICE_NAMES", testsDetails.DeviceNames)
+			SetEnv("DISK_ZONES", testsDetails.DiskZones)
 	case "vm-poweroff":
 		envDetails.SetEnv("APP_VM_MOIDS", testsDetails.VMIds)
 	case "process-kill":


### PR DESCRIPTION
## Proposed changes
- Removes `DEVICE_NAME` from GCP pipeline and gcp-vm-disk-loss experiment BDD ENVs.
- Updates the zones of GCP resources from `us-central1-a` to `us-east1-b` to avoid resource bottlenecking in a single zone.

## Which Issues it Fixes
fixes #377, #378

## How has this been tested:
- [ ] Test environment
    * [ ] GKE
    * [ ] AWS
    * [ ] OpenShift
    * [x] KinD/k3s/k3d cluster
    * [ ] Others
 - [ ] Tested with production environment ( For ChaosCenter Tests )
 - [ ] Have not tested

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus-e2e/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [ ] I have added necessary documentation (if appropriate)
- [x] I have added Screenshots or Terminal snippets in the PR comment to validate the successful execution of changes

**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] data-cy=* parameters have been added in codebase ( ChaosCenter Tests )
- [ ] data-cy=* parameters need to be added in codebase ( ChaosCenter Tests )
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. uncaught exceptions from 3rd party library (if any)

**Issue**
- [x] Tasks in issue are checked off

**Notes For Reviewer**
Demo Github Action execution with the changes: https://github.com/neelanjan00/litmus-e2e/actions/runs/2336553137