### PR TITLE
Updated project setup and uncommented all failing tests

### DIFF
--- a/Cypress/cypress/fixtures/endpoints.js
+++ b/Cypress/cypress/fixtures/endpoints.js
@@ -1,4 +1,5 @@
-export const endpoints = {
+const endpoints = {
+  query: () => "/query",
   status: () => "/status",
   login: () => "/login",
   getAllUsers: () => "/users",
@@ -19,3 +20,5 @@ export const endpoints = {
   removeInvitation: () => "/remove_invitation",
   leaveProject: () => "/leave_project",
 };
+
+export default endpoints;

--- a/Cypress/cypress/fixtures/errorCodes.js
+++ b/Cypress/cypress/fixtures/errorCodes.js
@@ -1,3 +1,4 @@
 export const unauthorized = "unauthorized";
 export const invalid_request = "invalid_request";
 export const permission_denied = "permission_denied";
+export const invalid_role = "invalid role";

--- a/Cypress/cypress/fixtures/graphql/mutations/workflows.js
+++ b/Cypress/cypress/fixtures/graphql/mutations/workflows.js
@@ -23,7 +23,7 @@ export const UPDATE_SCHEDULE = `
 `;
 
 export const RERUN_CHAOS_WORKFLOW = `
-  mutation reRunChaosWorkflow($projectID: String!, $workflowID: String!) {
+  mutation reRunChaosWorkFlow($projectID: String!, $workflowID: String!){
     reRunChaosWorkFlow(projectID: $projectID, workflowID: $workflowID)
   }
 `;

--- a/Cypress/cypress/integration/Api_Tests/authentication/user.spec.js
+++ b/Cypress/cypress/integration/Api_Tests/authentication/user.spec.js
@@ -1,7 +1,7 @@
 /// <reference types="Cypress" />
 
 import * as user from "../../../fixtures/Users.json";
-import { endpoints } from "../../../fixtures/authenticationEndpoints";
+import endpoints from "../../../fixtures/endpoints";
 import { unauthorized, invalid_request } from "../../../fixtures/errorCodes";
 
 let adminAccessToken, user1AccessToken, user1Id, adminUserId;
@@ -494,23 +494,23 @@ describe("Testing post request to updateState api", () => {
   });
 
   // Should give error but currently considering null value to be false
-  // it("Testing api from admin account without is_deactivate [ Should not be possible ]", () => {
-  //   cy.request({
-  //     method: "POST",
-  //     url: Cypress.env("authURL") + endpoints.updateState(),
-  //     headers: {
-  //       authorization: `Bearer ${adminAccessToken}`,
-  //     },
-  //     body: {
-  //       username: user.user1.username,
-  //     },
-  //     failOnStatusCode: false,
-  //   }).then((res) => {
-  //     expect(res.body).to.have.property("error");
-  //     expect(res.body).to.have.property("error_description");
-  //     expect(res.body.error).to.eq(invalid_request);
-  //   });
-  // });
+  it("Testing api from admin account without is_deactivate [ Should not be possible ]", () => {
+    cy.request({
+      method: "POST",
+      url: Cypress.env("authURL") + endpoints.updateState(),
+      headers: {
+        authorization: `Bearer ${adminAccessToken}`,
+      },
+      body: {
+        username: user.user1.username,
+      },
+      failOnStatusCode: false,
+    }).then((res) => {
+      expect(res.body).to.have.property("error");
+      expect(res.body).to.have.property("error_description");
+      expect(res.body.error).to.eq(invalid_request);
+    });
+  });
 
   it("Testing api from user account [ Should not be possible ]", () => {
     cy.request({

--- a/Cypress/cypress/integration/Api_Tests/graphql/cluster.spec.js
+++ b/Cypress/cypress/integration/Api_Tests/graphql/cluster.spec.js
@@ -3,33 +3,39 @@
 import * as user from "../../../fixtures/Users.json";
 import {
   REGISTER_CLUSTER,
-  // DELETE_CLUSTER,
+  DELETE_CLUSTER,
 } from "../../../fixtures/graphql/mutations";
 import { GET_CLUSTER } from "../../../fixtures/graphql/queries";
+import endpoints from "../../../fixtures/endpoints";
 
 let project1Id, project2Id, cluster1Id;
 before("Clear database", () => {
   cy.task("clearDB")
     .then(() => {
-      return cy.createAgent("a1");
+      return cy.requestLogin(user.AdminName, user.AdminPassword);
     })
     .then(() => {
-      return cy.task("getAdminProject");
+      return cy.createProject("admin's project");
+    })
+    .then((projectId) => {
+      project1Id = projectId;
+      return cy.createNamespaceAgent("a1", project1Id);
+    })
+    .then(() => {
+      let usersData = [user.user1, user.user2, user.user3];
+      return cy.createTestUsers(usersData);
     })
     .then((res) => {
-      return cy.securityCheckSetup(res._id, res.name);
+      return cy.createTestProjects(project1Id, res[0], res[1], res[2]);
     })
-    .then((createdSetupVariable) => {
-      project1Id = createdSetupVariable.project1Id;
-      project2Id = createdSetupVariable.project2Id;
-    })
-    .then(() => {
+    .then((res) => {
+      project2Id = res.project2Id;
       cy.requestLogin(user.AdminName, user.AdminPassword);
     })
     .then(() => {
       cy.request({
         method: "POST",
-        url: Cypress.env("apiURL") + "/query",
+        url: Cypress.env("apiURL") + endpoints.query(),
         body: {
           operationName: "listClusters",
           variables: {
@@ -47,7 +53,7 @@ describe("Testing cluster api", () => {
   it("Registering a new cluster", () => {
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + "/query",
+      url: Cypress.env("apiURL") + endpoints.query(),
       body: {
         operationName: "registerCluster",
         variables: {
@@ -76,10 +82,10 @@ describe("Testing cluster api", () => {
     });
   });
 
-  /*it("Testing input validation in registering a new cluster", () => {
+  it("Testing input validation in registering a new cluster", () => {
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + "/query",
+      url: Cypress.env("apiURL") + endpoints.query(),
       body: {
         operationName: "registerCluster",
         variables: {
@@ -98,12 +104,12 @@ describe("Testing cluster api", () => {
     }).then((res) => {
       cy.validateErrorMessage(res, "permission_denied");
     });
-  });*/
+  });
 
-  /*it("Registering a new cluster with same name", () => {
+  it("Registering a new cluster with same name", () => {
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + "/query",
+      url: Cypress.env("apiURL") + endpoints.query(),
       body: {
         operationName: "registerCluster",
         variables: {
@@ -116,18 +122,18 @@ describe("Testing cluster api", () => {
             tolerations: [],
           },
         },
-        query: REGISTER_CLUSTER`,
+        query: REGISTER_CLUSTER,
       },
       failOnStatusCode: false,
     }).then((res) => {
       cy.validateErrorMessage(res, "permission_denied");
     });
-  });*/
+  });
 
   it("Listing all cluster", () => {
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + "/query",
+      url: Cypress.env("apiURL") + endpoints.query(),
       body: {
         operationName: "listClusters",
         variables: {
@@ -142,10 +148,10 @@ describe("Testing cluster api", () => {
     });
   });
 
-  /*it("Deleting a cluster", () => {
+  it("Deleting a cluster", () => {
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + "/query",
+      url: Cypress.env("apiURL") + endpoints.query(),
       body: {
         operationName: "deleteClusters",
         variables: {
@@ -160,7 +166,7 @@ describe("Testing cluster api", () => {
         expect(res.body).to.have.nested.property("data.deleteClusterReg");
         return cy.request({
           method: "POST",
-          url: Cypress.env("apiURL") + "/query",
+          url: Cypress.env("apiURL") + endpoints.query(),
           body: {
             operationName: "listClusters",
             variables: {
@@ -176,5 +182,5 @@ describe("Testing cluster api", () => {
         expect(res.body.data.listClusters).to.be.an("array");
         expect(res.body.data.listClusters.length).to.eq(1);
       });
-  });*/
+  });
 });

--- a/Cypress/cypress/integration/Api_Tests/graphql/gitops.spec.js
+++ b/Cypress/cypress/integration/Api_Tests/graphql/gitops.spec.js
@@ -8,6 +8,7 @@ import {
   DISABLE_GITOPS,
 } from "../../../fixtures/graphql/mutations";
 import { GET_GITOPS_DATA } from "../../../fixtures/graphql/queries";
+import endpoints from "../../../fixtures/endpoints";
 
 let project1Id, project2Id;
 before("Clear database", () => {
@@ -16,17 +17,21 @@ before("Clear database", () => {
       return cy.requestLogin(user.AdminName, user.AdminPassword);
     })
     .then(() => {
-      return cy.getStarted("litmus");
+      return cy.createProject("admin's project");
+    })
+    .then((projectId) => {
+      project1Id = projectId;
+      return cy.createNamespaceAgent("a1", project1Id);
     })
     .then(() => {
-      return cy.task("getAdminProject");
+      let usersData = [user.user1, user.user2, user.user3];
+      return cy.createTestUsers(usersData);
     })
     .then((res) => {
-      return cy.securityCheckSetup(res._id, res.name);
+      return cy.createTestProjects(project1Id, res[0], res[1], res[2]);
     })
-    .then((createdSetupVariable) => {
-      project1Id = createdSetupVariable.project1Id;
-      project2Id = createdSetupVariable.project2Id;
+    .then((res) => {
+      project2Id = res.project2Id;
       cy.requestLogin(user.user3.username, user.user3.password);
     });
 });
@@ -35,7 +40,7 @@ describe("Testing GitOps api", () => {
   it("Enabling Gitops by user with viewer access", () => {
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + "/query",
+      url: Cypress.env("apiURL") + endpoints.query(),
       body: {
         operationName: "enableGitOps",
         variables: {
@@ -59,7 +64,7 @@ describe("Testing GitOps api", () => {
     cy.requestLogin(user.user2.username, user.user2.password);
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + "/query",
+      url: Cypress.env("apiURL") + endpoints.query(),
       body: {
         operationName: "enableGitOps",
         variables: {
@@ -83,7 +88,7 @@ describe("Testing GitOps api", () => {
     cy.requestLogin(user.AdminName, user.AdminPassword);
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + "/query",
+      url: Cypress.env("apiURL") + endpoints.query(),
       body: {
         operationName: "enableGitOps",
         variables: {
@@ -108,7 +113,7 @@ describe("Testing GitOps api", () => {
     cy.requestLogin(user.user3.username, user.user3.password);
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + "/query",
+      url: Cypress.env("apiURL") + endpoints.query(),
       body: {
         operationName: "getGitOpsDetails",
         variables: {
@@ -127,7 +132,7 @@ describe("Testing GitOps api", () => {
     cy.requestLogin(user.user2.username, user.user2.password);
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + "/query",
+      url: Cypress.env("apiURL") + endpoints.query(),
       body: {
         operationName: "getGitOpsDetails",
         variables: {
@@ -146,7 +151,7 @@ describe("Testing GitOps api", () => {
     cy.requestLogin(user.AdminName, user.AdminPassword);
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + "/query",
+      url: Cypress.env("apiURL") + endpoints.query(),
       body: {
         operationName: "getGitOpsDetails",
         variables: {
@@ -174,7 +179,7 @@ describe("Testing GitOps api", () => {
     cy.requestLogin(user.user3.username, user.user3.password);
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + "/query",
+      url: Cypress.env("apiURL") + endpoints.query(),
       body: {
         operationName: "updateGitOps",
         variables: {
@@ -197,7 +202,7 @@ describe("Testing GitOps api", () => {
     cy.requestLogin(user.user2.username, user.user2.password);
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + "/query",
+      url: Cypress.env("apiURL") + endpoints.query(),
       body: {
         operationName: "updateGitOps",
         variables: {
@@ -220,7 +225,7 @@ describe("Testing GitOps api", () => {
     cy.requestLogin(user.AdminName, user.AdminPassword);
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + "/query",
+      url: Cypress.env("apiURL") + endpoints.query(),
       body: {
         operationName: "updateGitOps",
         variables: {
@@ -239,7 +244,7 @@ describe("Testing GitOps api", () => {
         expect(res.body.data.updateGitOps).to.eq(true);
         return cy.request({
           method: "POST",
-          url: Cypress.env("apiURL") + "/query",
+          url: Cypress.env("apiURL") + endpoints.query(),
           body: {
             operationName: "getGitOpsDetails",
             variables: {
@@ -275,7 +280,7 @@ describe("Testing GitOps api", () => {
     cy.requestLogin(user.user3.username, user.user3.password);
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + "/query",
+      url: Cypress.env("apiURL") + endpoints.query(),
       body: {
         operationName: "disableGitOps",
         variables: {
@@ -294,7 +299,7 @@ describe("Testing GitOps api", () => {
     cy.requestLogin(user.user2.username, user.user2.password);
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + "/query",
+      url: Cypress.env("apiURL") + endpoints.query(),
       body: {
         operationName: "disableGitOps",
         variables: {
@@ -313,7 +318,7 @@ describe("Testing GitOps api", () => {
     cy.requestLogin(user.AdminName, user.AdminPassword);
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + "/query",
+      url: Cypress.env("apiURL") + endpoints.query(),
       body: {
         operationName: "disableGitOps",
         variables: {
@@ -328,7 +333,7 @@ describe("Testing GitOps api", () => {
         expect(res.body.data.disableGitOps).to.eq(true);
         return cy.request({
           method: "POST",
-          url: Cypress.env("apiURL") + "/query",
+          url: Cypress.env("apiURL") + endpoints.query(),
           body: {
             operationName: "getGitOpsDetails",
             variables: {

--- a/Cypress/cypress/integration/Api_Tests/graphql/imageRegistry.spec.js
+++ b/Cypress/cypress/integration/Api_Tests/graphql/imageRegistry.spec.js
@@ -8,25 +8,26 @@ import {
   DELETE_IMAGE_REGISTRY,
 } from "../../../fixtures/graphql/mutations";
 import { GET_IMAGE_REGISTRY } from "../../../fixtures/graphql/queries";
+import endpoints from "../../../fixtures/endpoints";
 
-let project1Id, project2Id, imageRegistryID;
+let project1Id, imageRegistryID;
 before("Clear database", () => {
   cy.task("clearDB")
     .then(() => {
       return cy.requestLogin(user.AdminName, user.AdminPassword);
     })
     .then(() => {
-      return cy.getStarted("litmus");
+      return cy.createProject("admin's project");
     })
-    .then(() => {
-      return cy.task("getAdminProject");
+    .then((projectId) => {
+      project1Id = projectId;
+      let usersData = [user.user1, user.user2, user.user3];
+      return cy.createTestUsers(usersData);
     })
     .then((res) => {
-      return cy.securityCheckSetup(res._id, res.name);
+      return cy.createTestProjects(project1Id, res[0], res[1], res[2]);
     })
-    .then((createdSetupVariable) => {
-      project1Id = createdSetupVariable.project1Id;
-      project2Id = createdSetupVariable.project2Id;
+    .then(() => {
       cy.requestLogin(user.user3.username, user.user3.password);
     });
 });
@@ -35,7 +36,7 @@ describe("Testing image registry api", () => {
   it("Create image registry by user with viewer access", () => {
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + "/query",
+      url: Cypress.env("apiURL") + endpoints.query(),
       body: {
         operationName: "createImageRegistry",
         variables: {
@@ -53,7 +54,7 @@ describe("Testing image registry api", () => {
   it("Create image registry by user with no access", () => {
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + "/query",
+      url: Cypress.env("apiURL") + endpoints.query(),
       body: {
         operationName: "createImageRegistry",
         variables: {
@@ -73,7 +74,7 @@ describe("Testing image registry api", () => {
     cy.requestLogin(user.AdminName, user.AdminPassword);
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + "/query",
+      url: Cypress.env("apiURL") + endpoints.query(),
       body: {
         operationName: "createImageRegistry",
         variables: {
@@ -94,7 +95,7 @@ describe("Testing image registry api", () => {
     cy.requestLogin(user.user3.username, user.user3.password);
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + "/query",
+      url: Cypress.env("apiURL") + endpoints.query(),
       body: {
         operationName: "getImageRegistry",
         variables: {
@@ -114,7 +115,7 @@ describe("Testing image registry api", () => {
     cy.requestLogin(user.user2.username, user.user2.password);
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + "/query",
+      url: Cypress.env("apiURL") + endpoints.query(),
       body: {
         operationName: "getImageRegistry",
         variables: {
@@ -134,7 +135,7 @@ describe("Testing image registry api", () => {
     cy.requestLogin(user.AdminName, user.AdminPassword);
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + "/query",
+      url: Cypress.env("apiURL") + endpoints.query(),
       body: {
         operationName: "getImageRegistry",
         variables: {
@@ -169,7 +170,7 @@ describe("Testing image registry api", () => {
     cy.requestLogin(user.user3.username, user.user3.password);
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + "/query",
+      url: Cypress.env("apiURL") + endpoints.query(),
       body: {
         operationName: "updateImageRegistry",
         variables: {
@@ -190,7 +191,7 @@ describe("Testing image registry api", () => {
     cy.requestLogin(user.user2.username, user.user2.password);
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + "/query",
+      url: Cypress.env("apiURL") + endpoints.query(),
       body: {
         operationName: "updateImageRegistry",
         variables: {
@@ -211,7 +212,7 @@ describe("Testing image registry api", () => {
     cy.requestLogin(user.AdminName, user.AdminPassword);
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + "/query",
+      url: Cypress.env("apiURL") + endpoints.query(),
       body: {
         operationName: "updateImageRegistry",
         variables: {
@@ -227,7 +228,7 @@ describe("Testing image registry api", () => {
         expect(res.body).to.have.nested.property("data.updateImageRegistry");
         return cy.request({
           method: "POST",
-          url: Cypress.env("apiURL") + "/query",
+          url: Cypress.env("apiURL") + endpoints.query(),
           body: {
             operationName: "getImageRegistry",
             variables: {
@@ -264,7 +265,7 @@ describe("Testing image registry api", () => {
     cy.requestLogin(user.user3.username, user.user3.password);
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + "/query",
+      url: Cypress.env("apiURL") + endpoints.query(),
       body: {
         operationName: "deleteImageRegistry",
         variables: {
@@ -284,7 +285,7 @@ describe("Testing image registry api", () => {
     cy.requestLogin(user.user2.username, user.user2.password);
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + "/query",
+      url: Cypress.env("apiURL") + endpoints.query(),
       body: {
         operationName: "deleteImageRegistry",
         variables: {
@@ -304,7 +305,7 @@ describe("Testing image registry api", () => {
     cy.requestLogin(user.AdminName, user.AdminPassword);
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + "/query",
+      url: Cypress.env("apiURL") + endpoints.query(),
       body: {
         operationName: "deleteImageRegistry",
         variables: {

--- a/Cypress/cypress/integration/Api_Tests/graphql/myhub.spec.js
+++ b/Cypress/cypress/integration/Api_Tests/graphql/myhub.spec.js
@@ -17,6 +17,7 @@ import {
 } from "../../../fixtures/graphql/queries";
 import * as myhubInput from "../../../fixtures/myhubInput.json";
 import { permission_denied } from "../../../fixtures/errorCodes";
+import endpoints from "../../../fixtures/endpoints";
 
 let project1Id, project2Id, hubId;
 before("Clear database", () => {
@@ -25,19 +26,18 @@ before("Clear database", () => {
       return cy.requestLogin(user.AdminName, user.AdminPassword);
     })
     .then(() => {
-      return cy.getStarted("litmus");
+      return cy.createProject("admin's project");
     })
-    .then(() => {
-      return cy.task("getAdminProject");
+    .then((projectId) => {
+      project1Id = projectId;
+      let usersData = [user.user1, user.user2, user.user3];
+      return cy.createTestUsers(usersData);
     })
     .then((res) => {
-      return cy.securityCheckSetup(res._id, res.name);
+      return cy.createTestProjects(project1Id, res[0], res[1], res[2]);
     })
-    .then((createdSetupVariable) => {
-      project1Id = createdSetupVariable.project1Id;
-      project2Id = createdSetupVariable.project2Id;
-    })
-    .then(() => {
+    .then((res) => {
+      project2Id = res.project2Id;
       cy.requestLogin(user.AdminName, user.AdminPassword);
     });
 });
@@ -46,7 +46,7 @@ describe("Testing myHub api", () => {
   it("Adding a new MyHub to a project with no access [ Should not be possible ]", () => {
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + "/query",
+      url: Cypress.env("apiURL") + endpoints.query(),
       body: {
         operationName: "addChaosHub",
         variables: {
@@ -66,7 +66,7 @@ describe("Testing myHub api", () => {
   it("Fetching status of the MyHub of a project with no access [ Should not be possible ]", () => {
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + "/query",
+      url: Cypress.env("apiURL") + endpoints.query(),
       body: {
         operationName: "listHubStatus",
         variables: {
@@ -85,7 +85,7 @@ describe("Testing myHub api", () => {
     cy.requestLogin(user.user2.username, user.user2.password);
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + "/query",
+      url: Cypress.env("apiURL") + endpoints.query(),
       body: {
         operationName: "addChaosHub",
         variables: {
@@ -105,7 +105,7 @@ describe("Testing myHub api", () => {
   it("Fetching status of the MyHub of a project with viewer access", () => {
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + "/query",
+      url: Cypress.env("apiURL") + endpoints.query(),
       body: {
         operationName: "listHubStatus",
         variables: {
@@ -124,7 +124,7 @@ describe("Testing myHub api", () => {
     cy.requestLogin(user.user1.username, user.user1.password);
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + "/query",
+      url: Cypress.env("apiURL") + endpoints.query(),
       body: {
         operationName: "addChaosHub",
         variables: {
@@ -135,6 +135,7 @@ describe("Testing myHub api", () => {
         },
         query: ADD_MY_HUB,
       },
+      timeout: 600000,
     }).then((res) => {
       expect(res.status).to.eq(200);
       expect(res.body).to.have.nested.property("data.addChaosHub.id");
@@ -145,7 +146,7 @@ describe("Testing myHub api", () => {
   it("Fetching status of the MyHub of a project with editor access", () => {
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + "/query",
+      url: Cypress.env("apiURL") + endpoints.query(),
       body: {
         operationName: "listHubStatus",
         variables: {
@@ -162,7 +163,7 @@ describe("Testing myHub api", () => {
   it("Fetching all the charts from hub of a project with editor access", () => {
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + "/query",
+      url: Cypress.env("apiURL") + endpoints.query(),
       body: {
         operationName: "listCharts",
         variables: {
@@ -181,7 +182,7 @@ describe("Testing myHub api", () => {
   it("Fetching the experiment details from a selected chart of a project with editor access", () => {
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + "/query",
+      url: Cypress.env("apiURL") + endpoints.query(),
       body: {
         operationName: "getHubExperiment",
         variables: {
@@ -206,7 +207,7 @@ describe("Testing myHub api", () => {
   it("Fetching the experiment manifest from the hub of a project with editor access", () => {
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + "/query",
+      url: Cypress.env("apiURL") + endpoints.query(),
       body: {
         operationName: "getYAMLData",
         variables: {
@@ -229,7 +230,7 @@ describe("Testing myHub api", () => {
   it("Fetching all the pre-defined workflows of a project with editor access", () => {
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + "/query",
+      url: Cypress.env("apiURL") + endpoints.query(),
       body: {
         operationName: "listPredefinedWorkflows",
         variables: {
@@ -238,6 +239,7 @@ describe("Testing myHub api", () => {
         },
         query: GET_PREDEFINED_WORKFLOW_LIST,
       },
+      timeout: 600000,
     }).then((res) => {
       expect(res.status).to.eq(200);
       expect(res.body).to.have.nested.property(
@@ -249,7 +251,7 @@ describe("Testing myHub api", () => {
   it("Fetching the experiment manifest from a hub of a project with editor access", () => {
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + "/query",
+      url: Cypress.env("apiURL") + endpoints.query(),
       body: {
         operationName: "getPredefinedExperimentYAML",
         variables: {
@@ -274,7 +276,7 @@ describe("Testing myHub api", () => {
   it("Updating the hub configuration of a project with editor access", () => {
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + "/query",
+      url: Cypress.env("apiURL") + endpoints.query(),
       body: {
         operationName: "updateChaosHub",
         variables: {
@@ -297,7 +299,7 @@ describe("Testing myHub api", () => {
   it("Syncing the hub of a project with editor access", () => {
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + "/query",
+      url: Cypress.env("apiURL") + endpoints.query(),
       body: {
         operationName: "syncChaosHub",
         variables: {
@@ -317,7 +319,7 @@ describe("Testing myHub api", () => {
     cy.requestLogin(user.user2.username, user.user2.password);
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + "/query",
+      url: Cypress.env("apiURL") + endpoints.query(),
       body: {
         operationName: "updateChaosHub",
         variables: {
@@ -339,7 +341,7 @@ describe("Testing myHub api", () => {
   it("Fetching all the charts from hub of a project with no access [ Should not be possible ]", () => {
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + "/query",
+      url: Cypress.env("apiURL") + endpoints.query(),
       body: {
         operationName: "listCharts",
         variables: {
@@ -357,7 +359,7 @@ describe("Testing myHub api", () => {
   it("Fetching the experiment details from a selected chart of a project with no access [ Should not be possible ]s", () => {
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + "/query",
+      url: Cypress.env("apiURL") + endpoints.query(),
       body: {
         operationName: "getHubExperiment",
         variables: {
@@ -376,128 +378,131 @@ describe("Testing myHub api", () => {
     });
   });
 
-  /*   it("Fetching the experiment manifest from the hub of a project with no access [ Should not be possible ]", () => {
+  it("Fetching the experiment manifest from the hub of a project with no access [ Should not be possible ]", () => {
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + '/query',
-      body: { 
-        "operationName": "getYAMLData",
-        "variables": {
-          "request": {
-            "projectID": project1Id,
-            "chartName": "generic",
-            "experimentName": "pod-delete",
-            "hubName": "my-chaos-hub-1",
-            "fileType": "EXPERIMENT"
-          }
+      url: Cypress.env("apiURL") + endpoints.query(),
+      body: {
+        operationName: "getYAMLData",
+        variables: {
+          request: {
+            projectID: project1Id,
+            chartName: "generic",
+            experimentName: "pod-delete",
+            hubName: "my-chaos-hub-1",
+            fileType: "EXPERIMENT",
+          },
         },
-        "query": GET_EXPERIMENT_YAML
+        query: GET_EXPERIMENT_YAML,
       },
-      failOnStatusCode: false
+      failOnStatusCode: false,
     }).then((res) => {
       cy.validateErrorMessage(res, permission_denied);
     });
-  }); */
+  });
 
-  /*   it("Fetching all the pre-defined workflows of a project with no access [ Should not be possible ]", () => {
+  it("Fetching all the pre-defined workflows of a project with no access [ Should not be possible ]", () => {
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + '/query',
-      body: { 
-        "operationName": "listPredefinedWorkflows",
-        "variables": {
-          "hubName": "my-chaos-hub-1",
-          "projectID": project1Id,
+      url: Cypress.env("apiURL") + endpoints.query(),
+      body: {
+        operationName: "listPredefinedWorkflows",
+        variables: {
+          hubName: "my-chaos-hub-1",
+          projectID: project1Id,
         },
-        "query": GET_PREDEFINED_WORKFLOW_LIST
+        query: GET_PREDEFINED_WORKFLOW_LIST,
       },
-      failOnStatusCode: false
+      failOnStatusCode: false,
     }).then((res) => {
       cy.validateErrorMessage(res, permission_denied);
     });
-  }); */
+  });
 
-  /*   it("Fetching the pre-defined experiment manifest from a hub of a project with no access [ Should not be possible ]", () => {
+  it("Fetching the pre-defined experiment manifest from a hub of a project with no access [ Should not be possible ]", () => {
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + '/query',
-      body: { 
-        "operationName": "getPredefinedExperimentYAML",
-        "variables": {
-          "request": {
-            "projectID": project1Id,
-            "chartName": "predefined",
-            "experimentName": "podtato-head",
-            "hubName": "my-chaos-hub-1",
-            "fileType": "WORKFLOW"
-          }
+      url: Cypress.env("apiURL") + endpoints.query(),
+      body: {
+        operationName: "getPredefinedExperimentYAML",
+        variables: {
+          request: {
+            projectID: project1Id,
+            chartName: "predefined",
+            experimentName: "podtato-head",
+            hubName: "my-chaos-hub-1",
+            fileType: "WORKFLOW",
+          },
         },
-        "query": GET_PREDEFINED_EXPERIMENT_YAML
+        query: GET_PREDEFINED_EXPERIMENT_YAML,
       },
-      failOnStatusCode: false
+      failOnStatusCode: false,
     }).then((res) => {
       cy.validateErrorMessage(res, permission_denied);
     });
-  }); */
+  });
 
-  /*   it("Syncing the hub of a project with no access [ Should not be possible ]", () => {
+  it("Syncing the hub of a project with no access [ Should not be possible ]", () => {
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + '/query',
-      body: { 
-        "operationName": "syncChaosHub",
-        "variables": {
-          id: hubId
+      url: Cypress.env("apiURL") + endpoints.query(),
+      body: {
+        operationName: "syncChaosHub",
+        variables: {
+          id: hubId,
+          projectID: project1Id,
         },
-        "query": SYNC_REPO
+        query: SYNC_REPO,
       },
-      failOnStatusCode: false
+      failOnStatusCode: false,
     }).then((res) => {
       cy.validateErrorMessage(res, permission_denied);
     });
-  }); */
+  });
 
-  /*   it("Deleting the hub of a project with no access [ Should not be possible ]", () => {
+  it("Deleting the hub of a project with no access [ Should not be possible ]", () => {
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + '/query',
-      body: { 
-        "operationName": "deleteChaosHub",
-        "variables": {
-          "hubID": hubId
+      url: Cypress.env("apiURL") + endpoints.query(),
+      body: {
+        operationName: "deleteChaosHub",
+        variables: {
+          hubID: hubId,
+          projectID: project1Id,
         },
-        "query": DELETE_HUB
+        query: DELETE_HUB,
       },
-      failOnStatusCode: false
+      failOnStatusCode: false,
     }).then((res) => {
       cy.validateErrorMessage(res, permission_denied);
     });
-  }); */
+  });
 
-  /*   it("Deleting the hub of a project with viewer access [ Should not be possible ]", () => {
+  it("Deleting the hub of a project with viewer access [ Should not be possible ]", () => {
     cy.logout();
     cy.requestLogin(user.user3.username, user.user3.password);
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + '/query',
-      body: { 
-        "operationName": "deleteChaosHub",
-        "variables": {
-          "hubID": hubId
+      url: Cypress.env("apiURL") + endpoints.query(),
+      body: {
+        operationName: "deleteChaosHub",
+        variables: {
+          hubID: hubId,
+          projectID: project1Id,
         },
-        "query": DELETE_HUB
+        query: DELETE_HUB,
       },
     }).then((res) => {
       cy.validateErrorMessage(res, permission_denied);
     });
-  }); */
+  });
 
   it("Deleting the hub of a project with editor access", () => {
     cy.logout();
     cy.requestLogin(user.user1.username, user.user1.password);
     cy.request({
       method: "POST",
-      url: Cypress.env("apiURL") + "/query",
+      url: Cypress.env("apiURL") + endpoints.query(),
       body: {
         operationName: "deleteChaosHub",
         variables: {

--- a/Cypress/cypress/integration/Parallel_Tests/Account_Settings/2. teaming.spec.js
+++ b/Cypress/cypress/integration/Parallel_Tests/Account_Settings/2. teaming.spec.js
@@ -58,6 +58,7 @@ describe("Test case to check the Invitation Functionality (Invitation as a Viewe
   it("Logging in with newly created user & logout", () => {
     // //Login as the intivation receipent (Project creation required for sending invitation)
     cy.requestLogin(user1.username, user1.password);
+    cy.visit("/");
     cy.getStarted(user1.password);
     cy.validateScaffold();
     cy.wait(5000);
@@ -222,6 +223,7 @@ describe("Test case to check the Invitation Functionality (Invitation as an Edit
   it("Logging in with newly created user & logout", () => {
     // //Login as the intivation receipent (Project creation required for sending invitation)
     cy.requestLogin(user2.username, user2.password);
+    cy.visit("/");
     cy.getStarted(user2.password);
     cy.validateScaffold();
     cy.wait(5000);
@@ -231,7 +233,7 @@ describe("Test case to check the Invitation Functionality (Invitation as an Edit
   it("Logging In as Admin again, invite the user as viewer", () => {
     // //Login again as Admin
     cy.requestLogin(AdminName, AdminPassword);
-
+    cy.visit("/");
     //Visit the teaming section and invite the newly created user as viewer"
     cy.visit("/settings");
     cy.get("[data-cy=teaming]").should("be.visible").click();

--- a/Cypress/cypress/integration/Parallel_Tests/Data_Source/addDataSource.spec.js
+++ b/Cypress/cypress/integration/Parallel_Tests/Data_Source/addDataSource.spec.js
@@ -7,6 +7,7 @@ export const dataSourceUrl = Cypress.env("DATA_SOURCE_URL");
 describe("Testing the addition of data source", () => {
   before("Clearing the Cookies and deleting the Cookies", () => {
     cy.requestLogin(user.AdminName, user.AdminPassword);
+    cy.visit("/");
     cy.waitForCluster(agent);
   });
 

--- a/Cypress/cypress/integration/smoke/smoke.spec.js
+++ b/Cypress/cypress/integration/smoke/smoke.spec.js
@@ -9,6 +9,7 @@ import {
   preDefinedWorkflowSmokeTest,
   templateWorkflowSmokeTest,
   uploadWorkflowSmokeTest,
+  setup,
 } from "./smoke";
 
 it("Smoke Test Login Page", () => {

--- a/Cypress/cypress/pages/login.js
+++ b/Cypress/cypress/pages/login.js
@@ -23,6 +23,4 @@ Cypress.Commands.add("requestLogin", (loginName, loginPassword) => {
     .then((res) => {
       cy.setCookie("litmus-cc-token", res.access_token);
     });
-  cy.wait(500);
-  cy.visit("/");
 });

--- a/Cypress/cypress/plugins/index.js
+++ b/Cypress/cypress/plugins/index.js
@@ -18,7 +18,12 @@
 
 const { rmdir } = require("fs");
 const MongoClient = require("mongodb").MongoClient;
-const MONGO_URL = "mongodb://admin:1234@" + process.env.CYPRESS_MONGO_URL;
+
+const MONGO_URL =
+  "mongodb://admin:1234@" +
+  (process.env.CYPRESS_MONGO_URL
+    ? process.env.CYPRESS_MONGO_URL
+    : "localhost:27017");
 
 async function drop(databaseName, mongoClient, collectionName) {
   const collection = mongoClient.db(databaseName).collection(collectionName);


### PR DESCRIPTION
## Proposed changes

- Updated all test cases to take url from fixtures
- Uncomment all commented tests and added the report [here](https://github.com/litmuschaos/litmus-e2e/issues/362#issuecomment-1162638528)
- Divided setup function into multiple smaller reusable functions
- Reduced tests time by removing waiting period between each login.
- Added fallback to local mongodb if environment variable is not set

## How has this been tested:
- [ ] Test environment
    * [ ] GKE
    * [ ] AWS
    * [ ] OpenShift
    * [ ] KinD/k3s/k3d cluster
    * [ ] Others
 - [x] Tested with production environment ( For ChaosCenter Tests )
 - [ ] Have not tested

## Types of changes

What types of changes does your code introduce to Litmus? Put an `x` in the boxes that apply
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus-e2e/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [x] I have added necessary documentation (if appropriate)
- [x] I have added Screenshots or Terminal snippets in the PR comment to validate the successful execution of changes

**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] data-cy=* parameters have been added in codebase ( ChaosCenter Tests )
- [ ] data-cy=* parameters need to be added in codebase ( ChaosCenter Tests )
- [x] No updates required.
