### PR TITLE
Fix Authentication Issues update Status Codes, password Policy, and add referer header

### DIFF
--- a/chaoscenter/cypress/e2e/REST APIs/UserManagment.cy.js
+++ b/chaoscenter/cypress/e2e/REST APIs/UserManagment.cy.js
@@ -65,7 +65,7 @@ describe('Test Cases for User-Management', () => {
         const edit_payload = {
             username: user.username,
             oldPassword: '',
-            newPassword: '1'
+            newPassword: '!Qwer1234'
           };
 
         cy.request({

--- a/chaoscenter/cypress/e2e/REST APIs/chaosProbes.cy.js
+++ b/chaoscenter/cypress/e2e/REST APIs/chaosProbes.cy.js
@@ -89,7 +89,7 @@ describe('Testing http chaos Probes', () => {
             }
         }).then((response) => {
             expect(response.status).to.equal(200);
-            expect(response.body.errors[0].message).to.equal('write exception: write errors: [E11000 duplicate key error collection: litmus.chaosProbes index: name_1 dup key: { name: "exp1111" }]');
+            expect(response.body.errors[0].message).to.contain('write exception: write errors: [E11000 duplicate key error collection:');
         });
     });
 
@@ -276,7 +276,7 @@ describe('testing CMD chaos probes', () => {
             },
         }).then((response) => {
             expect(response.status).to.equal(200);
-            expect(response.body.errors[0].message).to.equal('write exception: write errors: [E11000 duplicate key error collection: litmus.chaosProbes index: name_1 dup key: { name: "exp2222" }]');
+            expect(response.body.errors[0].message).to.contain('write exception: write errors: [E11000 duplicate key error collection:');
         });
     });
 
@@ -473,7 +473,7 @@ describe('testing prometheus chaos probes', () => {
             },
         }).then((response) => {
             expect(response.status).to.equal(200);
-            expect(response.body.errors[0].message).to.equal('write exception: write errors: [E11000 duplicate key error collection: litmus.chaosProbes index: name_1 dup key: { name: "exp3333" }]');
+            expect(response.body.errors[0].message).to.contain('write exception: write errors: [E11000 duplicate key error collection:');
         });
     });
 
@@ -667,7 +667,7 @@ describe('testing kubernetes chaos probes', () => {
             },
         }).then((response) => {
             expect(response.status).to.equal(200);
-            expect(response.body.errors[0].message).to.equal('write exception: write errors: [E11000 duplicate key error collection: litmus.chaosProbes index: name_1 dup key: { name: "exp4444" }]');
+            expect(response.body.errors[0].message).to.contain('write exception: write errors: [E11000 duplicate key error collection:');
     
         });
     });

--- a/chaoscenter/cypress/e2e/REST APIs/chaoshub.cy.js
+++ b/chaoscenter/cypress/e2e/REST APIs/chaoshub.cy.js
@@ -25,6 +25,7 @@ describe('testing chaoshub', () => {
       request: {
           name: 'testing',
           repoBranch: 'master',
+          remoteHub: 'GitHub',
           description: '',
           tags: [],
           authType: 'NONE',
@@ -82,6 +83,7 @@ describe('testing chaoshub', () => {
       request: {
           name: 'testing',
           repoBranch: 'master',
+          remoteHub: 'Github',
           description: '',
           tags: [],
           authType: 'NONE',
@@ -118,6 +120,7 @@ describe('testing chaoshub', () => {
           id: hubID,
           name: 'sample',
           repoBranch: 'master',
+          remoteHub: 'GitHub',
           description: '',
           authType: 'NONE',
           isPrivate: false,

--- a/chaoscenter/cypress/e2e/REST APIs/chaosinfra.cy.js
+++ b/chaoscenter/cypress/e2e/REST APIs/chaosinfra.cy.js
@@ -136,7 +136,7 @@ describe('testing chaosinfra via REST APIs', () => {
             }
         }).then((response) => {
             expect(response.status).to.equal(200);
-            expect(response.body.errors[0].message).to.equal('write exception: write errors: [E11000 duplicate key error collection: litmus.environment index: environment_id_1 dup key: { environment_id: "exp99" }]');
+            expect(response.body.errors[0].message).to.contain('write exception: write errors: [E11000 duplicate key error collection:');
         });
     });
 

--- a/chaoscenter/cypress/e2e/REST APIs/chaosinfra.cy.js
+++ b/chaoscenter/cypress/e2e/REST APIs/chaosinfra.cy.js
@@ -72,7 +72,8 @@ describe('testing chaosinfra via REST APIs', () => {
             url: '/api/query',
             body: registerInfra_payload,
             headers: {
-                Authorization: `Bearer ${accessToken}`
+                Authorization: `Bearer ${accessToken}`,
+                Referer: 'https://localhost:3000/'
             }
         }).then((response) => {
             expect(response.status).to.equal(200);
@@ -159,7 +160,8 @@ describe('testing chaosinfra via REST APIs', () => {
             method: 'POST',
             url: '/api/query', 
             headers: {
-                Authorization: `Bearer ${accessToken}`
+                Authorization: `Bearer ${accessToken}`,
+                Referer: 'https://localhost:3000/'
             },
             body: updateInfra_payload,
         }).then((response) => {

--- a/chaoscenter/cypress/e2e/REST APIs/login.cy.js
+++ b/chaoscenter/cypress/e2e/REST APIs/login.cy.js
@@ -13,7 +13,7 @@ describe('Testing login page of chaoscenter via REST APIs', () => {
           password: 'invalid_password',
       },
   }).then((response) => {
-      expect(response.status).to.equal(400);
+      expect(response.status).to.equal(401);
       expect(response.body.error).to.equal('invalid_credentials');
   });
   })

--- a/chaoscenter/cypress/e2e/UI/Usermanagment.cy.js
+++ b/chaoscenter/cypress/e2e/UI/Usermanagment.cy.js
@@ -31,8 +31,8 @@ describe('testing for User management', () => {
             cy.wrap(buttons[buttons.length - 1]).click();
         });
         cy.contains('Reset Password').click();
-        cy.get('input[name="password"]').type('22222');
-        cy.get('input[name="reEnterPassword"]').type('22222');
+        cy.get('input[name="password"]').type(user.resetpassword);
+        cy.get('input[name="reEnterPassword"]').type(user.resetpassword);
         cy.intercept('POST','/auth/reset/password').as('reset');
         cy.contains('Confirm').click();
         cy.wait('@reset');

--- a/chaoscenter/cypress/e2e/UI/chaoshub.cy.js
+++ b/chaoscenter/cypress/e2e/UI/chaoshub.cy.js
@@ -15,6 +15,8 @@ describe('testing chaoshub via UI', () => {
         cy.contains('Continue').click();
         cy.get('input[name="repoURL"]').type('https://github.com/litmuschaos/chaos-charts.git');
         cy.get('input[name="repoBranch"]').type('master');
+        cy.get('div[data-testid = "dropdown-button"]').click();
+        cy.contains('GitHub').click();
         cy.intercept('POST','/api/query').as('Query');
         cy.get('button[aria-label = "Connect Hub"]').click();
         cy.wait('@Query');
@@ -36,6 +38,8 @@ describe('testing chaoshub via UI', () => {
         cy.contains('Continue').click();
         cy.get('input[name="repoURL"]').type('1');
         cy.get('input[name="repoBranch"]').type('1');
+        cy.get('div[data-testid = "dropdown-button"]').click();
+        cy.contains('GitHub').click();
         cy.get('button[aria-label = "Connect Hub"]').click();
         cy.on('window:alert', () => {
             expect(message).to.equal('name already exists');

--- a/chaoscenter/cypress/e2e/UI/chaosinfra.cy.js
+++ b/chaoscenter/cypress/e2e/UI/chaosinfra.cy.js
@@ -24,7 +24,7 @@ describe('testing chaosinfra via UI', () => {
         cy.get('input[name="name"]').type('exp99');
         cy.contains('Save').click();
         cy.on('alert message', () => {
-            expect(message).to.equal('write exception: write errors: [E11000 duplicate key error collection: litmus.environment index: environment_id_1 dup key: { environment_id: "exp99" }]');
+            expect(message).to.contain('write exception: write errors: [E11000 duplicate key error collection:');
         });
     });
 

--- a/chaoscenter/cypress/fixtures/Users.json
+++ b/chaoscenter/cypress/fixtures/Users.json
@@ -2,6 +2,7 @@
     "user1": {
       "username": "user1",
       "password": "user1",
+      "resetpassword": "!Qwer1234",
       "role": "user",
       "email": "user1@litmus.com",
       "name": "Test Account 1"
@@ -9,6 +10,7 @@
     "user2": {
         "username": "user2",
         "password": "user2",
+        "resetpassword": "!Qwer1234",
         "role": "user",
         "email": "user2@litmus.com",
         "name": "Test Account 2"

--- a/chaoscenter/cypress/fixtures/chaoshub.js
+++ b/chaoscenter/cypress/fixtures/chaoshub.js
@@ -4,6 +4,7 @@ export const add_hub = `
             name
             repoURL
             repoBranch
+            remoteHub
             hubType
             isPrivate
             __typename
@@ -17,6 +18,7 @@ export const update_hub =`
             name
             repoURL
             repoBranch
+            remoteHub
             __typename
         }
     }
@@ -33,6 +35,7 @@ export const list_hub = `
             id
             repoURL
             repoBranch
+            remoteHub
             authType
             isAvailable
             totalFaults

--- a/chaoscenter/package.json
+++ b/chaoscenter/package.json
@@ -4,7 +4,7 @@
   "description": "Package for Testing",
   "main": "index.js",
   "scripts": {
-    "start": "cypress run",
+    "start": "cypress run"
   },
   "devDependencies": {
     "cypress": "^13.7.0",


### PR DESCRIPTION
## Proposed changes

- Expected response Status code 400 to 401 when user id and password is not correct
[graphql return status code](https://github.com/litmuschaos/litmus/blob/37fae3a4577ef80fb7d8ab26b67fd6059b75c702/chaoscenter/authentication/pkg/utils/errors.go#L32)
- remove comma
- new or reset Password are not working because password policy is changed 
- Add Request Header referer because graphql server check referer null 
- Add remoteHub field in the ChaosHub UI and API
- Update expected error equal to conatin because aws documentDB return different error 

```
assert expected 
AWS documentDB
write exception: write errors: [E11000 duplicate key error collection: chaosProbes index: name_1] to equal 

mongoDB
write exception: write errors: [E11000 duplicate key error collection: litmus.chaosProbes index: name_1 dup key: { name: "exp1111" }]
```

## How has this been tested:
- [x] Test environment
    * [ ] GKE
    * [x] AWS
    * [x] local 

## Checklist
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
- [x] I have read the [CONTRIBUTING](https://github.com/litmuschaos/litmus-e2e/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the commit for DCO to be passed.
- [] I have added necessary documentation (if appropriate)
- [ ] I have added Screenshots or Terminal snippets in the PR comment to validate the successful execution of changes

